### PR TITLE
解决嵌套 Git 仓库（子插件的 .git 目录）在备份和还原时导致档案流失或错误的问题，同时增加了自动存档的「创建存档」新模式功能

### DIFF
--- a/index.js
+++ b/index.js
@@ -102,44 +102,59 @@ async function ensureGitignoreHidden() {
     }
 }
 
-// 暫時將子資料夾(.git)偽裝，這樣 Git 就不會將其作為 Submodule，而是加入裡面所有的原始碼檔案
-async function maskNestedGit(targetPath) {
+// 核心修復：在隱藏 .git 的同時，強行注入我們的破解規則
+async function maskNestedGit(targetDir) {
     const maskedPaths = [];
-    try {
-        const entries = await fs.readdir(targetPath, { withFileTypes: true });
-        for (const entry of entries) {
-            const entryPath = path.join(targetPath, entry.name);
-            if (entry.isDirectory()) {
-                if (entry.name === '.git') {
-                    const hiddenPath = path.join(targetPath, '.git_cloud_hidden');
-                    try {
-                        await fs.rename(entryPath, hiddenPath);
-                        maskedPaths.push({ original: entryPath, hidden: hiddenPath });
-                    } catch (e) {
-                        console.error(`[cloud-saves] 無法偽裝 ${entryPath}:`, e);
+    async function scan(currentDir) {
+        try {
+            const entries = await fs.readdir(currentDir, { withFileTypes: true });
+            for (const entry of entries) {
+                const fullPath = path.join(currentDir, entry.name);
+                if (entry.isDirectory()) {
+                    if (entry.name === '.git') {
+                        const hiddenPath = path.join(currentDir, '.git_cloud_hidden');
+                        try {
+                            // 確保乾淨轉換
+                            await fs.rm(hiddenPath, { recursive: true, force: true }).catch(() => {});
+                            await fs.rename(fullPath, hiddenPath);
+                            
+                            // 【破解 1】防誤殺：強行植入最高權限的 .gitignore，突破所有擴展本身的忽略規則，強制備份 config！
+                            await fs.writeFile(path.join(hiddenPath, '.gitignore'), "# Force tracking\n!*");
+                            
+                            // 【破解 2】防骨架蒸發：為 Git 核心空目錄植入 .gitkeep，強迫 Git 備份這些血管與神經！
+                            const keepDirs = ['objects/info', 'objects/pack', 'refs/heads', 'refs/tags', 'branches', 'info'];
+                            for (const dir of keepDirs) {
+                                const keepPath = path.join(hiddenPath, dir);
+                                await fs.mkdir(keepPath, { recursive: true }).catch(() => {});
+                                await fs.writeFile(path.join(keepPath, '.gitkeep'), "").catch(() => {});
+                            }
+                            
+                            maskedPaths.push(fullPath);
+                        } catch (e) {
+                            console.error(`[cloud-saves] 無法隱藏 ${fullPath}:`, e);
+                        }
+                    } else if (entry.name !== '.git_cloud_hidden') {
+                        // 遞迴尋找下層
+                        await scan(fullPath);
                     }
-                } else if (entry.name !== '.git_cloud_hidden') {
-                    const subMasked = await maskNestedGit(entryPath);
-                    maskedPaths.push(...subMasked);
                 }
             }
-        }
-    } catch (error) {
-        if (error.code !== 'ENOENT') {
-            console.error(`[cloud-saves] 遞迴偽裝 .git 資料夾時發生錯誤 (${targetPath}):`, error);
-        }
+        } catch (e) {}
     }
+    await scan(targetDir);
     return maskedPaths;
 }
 
-// 在操作完成後將其還原為真正的 .git 資料夾
+// 還原時，將我們注入的破解規則一併打掃乾淨
 async function unmaskNestedGit(maskedPaths) {
-    for (const paths of maskedPaths) {
+    for (const originalGit of maskedPaths) {
+        const hiddenPath = originalGit.replace(/\.git$/, '.git_cloud_hidden');
         try {
-            await fs.rename(paths.hidden, paths.original);
-        } catch (e) {
-            console.error(`[cloud-saves] 無法還原 ${paths.hidden}:`, e);
-        }
+            // 清理注入的破破解 .gitignore
+            await fs.rm(path.join(hiddenPath, '.gitignore'), { force: true }).catch(() => {});
+            await fs.rm(originalGit, { recursive: true, force: true }).catch(() => {});
+            await fs.rename(hiddenPath, originalGit);
+        } catch (e) {}
     }
 }
 
@@ -529,53 +544,33 @@ async function listSaves() {
     }
 }
 
-// 新增：用於在 Git Checkout 讀取完畢後，不僅還原被拉下來的擴展 .git 資訊，同時進行 Git 骨架修復
+// 補救讀取被刪除的插件
 async function restoreCheckoutGit(targetPath) {
     try {
         const entries = await fs.readdir(targetPath, { withFileTypes: true });
         for (const entry of entries) {
             const entryPath = path.join(targetPath, entry.name);
             if (entry.isDirectory()) {
-                // 如果抓到了從雲端死灰復燃的隱藏 Git 檔案夾
                 if (entry.name === '.git_cloud_hidden') {
                     const originalGit = path.join(targetPath, '.git');
                     try {
-                        // 1. 確保目標是乾淨的，先強制移除可能衝突的損壞 .git
                         await fs.rm(originalGit, { recursive: true, force: true }).catch(() => {});
-                        
-                        // 2. 把從存檔拉下來的隱藏檔改回正統的 .git
                         await fs.rename(entryPath, originalGit);
+                        // 清理拉取下來的破解檔案
+                        await fs.rm(path.join(originalGit, '.gitignore'), { force: true }).catch(() => {});
                         
-                        // 3. 【核心修復機制】手動補齊 Git 運作所需的基礎空目錄！
-                        // 因為 Git 存檔時「不記錄空資料夾」，這會導致還原出來的 .git 壞掉
-                        // 把這些空目錄建回來，Git 就會重新承認這是一個正常的倉庫，SillyTavern 就能更新了
-                        const requiredGitDirs = [
-                            'objects/info',
-                            'objects/pack',
-                            'refs/heads',
-                            'refs/tags',
-                            'branches',
-                            'info'
-                        ];
+                        // 針對那些「使用舊代碼備份、從未被補救」的舊存檔作最後的骨架重建（盡力挽救舊檔用）
+                        const requiredGitDirs = ['objects/info', 'objects/pack', 'refs/heads', 'refs/tags', 'branches', 'info'];
                         for (const dirName of requiredGitDirs) {
                             await fs.mkdir(path.join(originalGit, dirName), { recursive: true }).catch(() => {});
                         }
-                        
-                        console.log(`[cloud-saves] 成功修復並還原被刪除擴展的 Git 資訊: ${targetPath}`);
-                    } catch (e) {
-                        console.error(`[cloud-saves] 無法還原/修復隱藏的 git 目錄 ${entryPath}:`, e);
-                    }
+                    } catch (e) {}
                 } else if (entry.name !== '.git') {
-                    // 只要不是 .git，就繼續往下層資料夾遞迴探查
                     await restoreCheckoutGit(entryPath);
                 }
             }
         }
-    } catch (error) {
-        if (error.code !== 'ENOENT') {
-            console.error(`[cloud-saves] 掃描還原 .git_cloud_hidden 時發生錯誤 (${targetPath}):`, error);
-        }
-    }
+    } catch (error) {}
 }
 
 // 完整版 loadSave，確保呼叫了上述修復機制

--- a/index.js
+++ b/index.js
@@ -419,8 +419,51 @@ async function listSaves() {
         console.log('[cloud-saves] 获取存档列表');
         const git = await getGitInstance();
 
-        console.log('[cloud-saves] Fetching and pruning remote tags...');
-        await git.fetch(['origin', '--tags', '--force', '--prune-tags']);
+        // 1. 使用 ls-remote 獲取當前遠端倉庫的「真實標籤清單」
+        console.log('[cloud-saves] Fetching remote tags list via ls-remote...');
+        let lsRemoteOutput = '';
+        try {
+            lsRemoteOutput = await git.listRemote(['--tags', 'origin']);
+        } catch (remoteErr) {
+            console.warn('[cloud-saves] 無法訪問遠端倉庫，可能是尚未初始化完成。', remoteErr.message);
+        }
+        
+        const remoteTags = new Set();
+        if (lsRemoteOutput) {
+            const lines = lsRemoteOutput.trim().split('\n');
+            for (const line of lines) {
+                if (!line) continue;
+                // 過濾出 save_ 開頭的標籤，並忽略 Git 特有的 ^{} 指標後綴
+                const match = line.match(/refs\/tags\/(save_[^\s\^]+)/);
+                if (match) {
+                    remoteTags.add(match[1]);
+                }
+            }
+        }
+
+        // 2. 清理本地殘留：找出本地所有的 save_ 標籤，把「不在當前遠端倉庫」的直接刪除
+        const localTagsSummary = await git.tags(['-l', 'save_*']);
+        const localTags = localTagsSummary.all || [];
+        let prunedCount = 0;
+        for (const localTag of localTags) {
+            if (!remoteTags.has(localTag)) {
+                try {
+                    await git.tag(['-d', localTag]);
+                    prunedCount++;
+                } catch(e) {}
+            }
+        }
+        if (prunedCount > 0) {
+            console.log(`[cloud-saves] 已清理 ${prunedCount} 個不屬於當前遠端倉庫的本地殘留存檔(標籤)。`);
+        }
+
+        // 3. 從遠端拉取最新的標籤資料到本地 (以獲取註解內容和日期)
+        console.log('[cloud-saves] Fetching tags data from remote...');
+        try {
+            await git.fetch(['origin', '--tags', '--force']);
+        } catch (fetchErr) {
+            console.warn('[cloud-saves] 拉取標籤時出現警告，如果是空倉庫則為正常現象。');
+        }
 
         const formatString = "%(refname:short)%00%(creatordate:iso)%00%(taggername)%00%(subject)%00%(contents)";
         const tagOutput = await git.raw('tag', '-l', 'save_*', '--sort=-creatordate', `--format=${formatString}`);
@@ -432,6 +475,10 @@ async function listSaves() {
             if (parts.length < 5) return null;
 
             const tagName = parts[0];
+            
+            // 【二次保險過濾】確保返回的標籤確實在遠端的清單中
+            if (!remoteTags.has(tagName)) return null;
+
             const createdAt = new Date(parts[1]).toISOString();
             const taggerName = parts[2] || '未知';
             const subject = parts[3];

--- a/index.js
+++ b/index.js
@@ -1259,7 +1259,7 @@ async function init(router) {
             }
         });
 
-        router.post('/saves/:tagName/overwrite', async (req, res) => {
+                router.post('/saves/:tagName/overwrite', async (req, res) => {
             if (currentOperation) return res.status(409).json({ success: false, message: `正在进行操作: ${currentOperation}` });
             currentOperation = 'overwrite_save';
             const { tagName } = req.params;
@@ -1319,4 +1319,29 @@ async function init(router) {
                 try {
                     await git.push('origin', tagName);
                 } catch (pushTagError) {
-                     await git.tag
+                     await git.tag(['-d', tagName]);
+                     throw pushTagError;
+                }
+                
+                res.json({ success: true, message: '存档覆盖成功', tag: tagName });
+
+            } catch (error) {
+                res.status(500).json({ success: false, message: '覆盖存档时发生意外错误', details: error.message });
+            } finally {
+                currentOperation = null;
+            }
+        });
+
+        // 啟動後台自動存檔計時器
+        setupBackendAutoSaveTimer();
+
+    } catch (error) {
+        console.error('[cloud-saves] 初始化插件期间发生错误:', error);
+    }
+} // 結束 init 函數
+
+// 匯出插件 (這段剛才被截斷了，是擴展能正常運作的關鍵)
+module.exports = {
+    info,
+    init
+};

--- a/index.js
+++ b/index.js
@@ -61,6 +61,8 @@ const DEFAULT_CONFIG = {
     autoSaveEnabled: false,
     autoSaveInterval: 30,
     autoSaveTargetTag: '',
+    autoSaveMode: 'overwrite',
+    autoSaveTimezoneOffset: 0,
 };
 
 let currentOperation = null;
@@ -74,6 +76,8 @@ async function readConfig() {
         config.autoSaveEnabled = config.autoSaveEnabled === undefined ? DEFAULT_CONFIG.autoSaveEnabled : config.autoSaveEnabled;
         config.autoSaveInterval = config.autoSaveInterval === undefined ? DEFAULT_CONFIG.autoSaveInterval : config.autoSaveInterval;
         config.autoSaveTargetTag = config.autoSaveTargetTag === undefined ? DEFAULT_CONFIG.autoSaveTargetTag : config.autoSaveTargetTag;
+        config.autoSaveMode = config.autoSaveMode === undefined ? DEFAULT_CONFIG.autoSaveMode : config.autoSaveMode;
+        config.autoSaveTimezoneOffset = config.autoSaveTimezoneOffset === undefined ? DEFAULT_CONFIG.autoSaveTimezoneOffset : config.autoSaveTimezoneOffset;
         return config;
     } catch (error) {
         console.warn('Failed to read or parse config, creating default:', error.message);
@@ -568,7 +572,7 @@ async function restoreCheckoutGit(targetPath) {
                         
                         // 清理掉我們強制追蹤的髒東西
                         await fs.rm(path.join(originalGit, '.gitignore'), { force: true }).catch(() => {});
-                        await fs.rm(path.join(originalGit, '.gitkeep'), { force: true }).catch(() => {}); // 順手清理根目錄可能存在的 gitkeep
+                        await fs.rm(path.join(originalGit, '.gitkeep'), { force: true }).catch(() => {});
                         
                         // 保險：強制建立基本空資料夾架構
                         const requiredGitDirs = ['objects/info', 'objects/pack', 'refs/heads', 'refs/tags', 'branches', 'info'];
@@ -829,7 +833,7 @@ async function getGitStatus() {
 
         let status = null;
         if (isInitialized) {
-            if (!currentOperation) { // 防止與備份時的 Mask 衝突
+            if (!currentOperation) {
                 const extensionsPath = path.join(DATA_DIR, 'default-user', 'extensions');
                 let maskedPaths = await maskNestedGit(extensionsPath);
                 try {
@@ -996,13 +1000,51 @@ async function performAutoSave() {
     let git;
     try {
         config = await readConfig();
-        if (!config.is_authorized || !config.autoSaveEnabled || !config.autoSaveTargetTag) {
+        if (!config.is_authorized || !config.autoSaveEnabled) {
+            currentOperation = null;
+            return;
+        }
+
+        const mode = config.autoSaveMode || 'overwrite';
+
+        if (mode === 'create') {
+            // 創建新存檔模式：像手動備份一樣創建新存檔
+            const offsetMinutes = config.autoSaveTimezoneOffset || 0;
+            // 根據瀏覽器時區偏移調整服務器UTC時間
+            const adjustedTime = new Date(Date.now() + offsetMinutes * 60 * 1000);
+            const year = adjustedTime.getUTCFullYear();
+            const month = String(adjustedTime.getUTCMonth() + 1).padStart(2, '0');
+            const day = String(adjustedTime.getUTCDate()).padStart(2, '0');
+            const hours = String(adjustedTime.getUTCHours()).padStart(2, '0');
+            const minutes = String(adjustedTime.getUTCMinutes()).padStart(2, '0');
+            const saveName = `${year}-${month}-${day} - ${hours}${minutes} (Auto Save)`;
+            
+            console.log(`[Cloud Saves Auto] 創建模式: 自動創建新存檔 "${saveName}"`);
+            
+            // 臨時清除 currentOperation 以便調用 createSave
+            currentOperation = null;
+            try {
+                const result = await createSave(saveName, 'Auto Save');
+                if (result.success) {
+                    console.log(`[Cloud Saves Auto] 成功創建自動存檔: ${result.saveData?.tag}`);
+                } else {
+                    console.error(`[Cloud Saves Auto] 創建自動存檔失敗: ${result.message}`);
+                }
+            } catch (createError) {
+                console.error(`[Cloud Saves Auto] 創建自動存檔異常:`, createError);
+            }
+            return;
+        }
+
+        // 以下是覆蓋模式 (overwrite) 的原有邏輯
+        if (!config.autoSaveTargetTag) {
+            console.log('[Cloud Saves Auto] 覆蓋模式需要目標標籤，但未設置');
             currentOperation = null;
             return;
         }
 
         const targetTag = config.autoSaveTargetTag;
-        console.log(`[Cloud Saves Auto] 开始自动覆盖存档到: ${targetTag}`);
+        console.log(`[Cloud Saves Auto] 開始自動覆蓋存檔到: ${targetTag}`);
         git = await getGitInstance();
         const branchToUse = config.branch || DEFAULT_BRANCH;
 
@@ -1043,7 +1085,7 @@ async function performAutoSave() {
             await unmaskNestedGit(maskedPaths);
         }
 
-        if (!newCommitHash) throw new Error('无法确定用于自动存档的提交哈希');
+        if (!newCommitHash) throw new Error('無法確定用於自動存檔的提交哈希');
 
         try { await git.tag(['-d', targetTag]); } catch (delLocalErr) {}
         try { await git.push(['origin', `:refs/tags/${targetTag}`]); } catch (delRemoteErr) {}
@@ -1058,10 +1100,10 @@ async function performAutoSave() {
              await git.tag(['-d', targetTag]);
              throw pushTagError;
         }
-        console.log(`[Cloud Saves Auto] 成功自动覆盖存档: ${targetTag}`);
+        console.log(`[Cloud Saves Auto] 成功自動覆蓋存檔: ${targetTag}`);
 
     } catch (error) {
-        console.error(`[Cloud Saves Auto] 自动覆盖存档失败 (${config?.autoSaveTargetTag}):`, error);
+        console.error(`[Cloud Saves Auto] 自動存檔失敗 (mode: ${config?.autoSaveMode}, tag: ${config?.autoSaveTargetTag}):`, error);
     } finally {
         currentOperation = null;
     }
@@ -1074,13 +1116,20 @@ function setupBackendAutoSaveTimer() {
     }
 
     readConfig().then(config => {
-        if (config.is_authorized && config.autoSaveEnabled && config.autoSaveTargetTag) {
+        if (config.is_authorized && config.autoSaveEnabled) {
+            const mode = config.autoSaveMode || 'overwrite';
+            // 創建模式不需要 targetTag，覆蓋模式需要
+            if (mode === 'overwrite' && !config.autoSaveTargetTag) {
+                console.log('[Cloud Saves] 覆蓋模式需要目標標籤，自動存檔定時器不會啟動');
+                return;
+            }
             let intervalMilliseconds = (config.autoSaveInterval > 0 ? config.autoSaveInterval : 30) * 60 * 1000;
             if (intervalMilliseconds < 60000) intervalMilliseconds = 60000;
             autoSaveBackendTimer = setInterval(performAutoSave, intervalMilliseconds);
+            console.log(`[Cloud Saves] 自動存檔定時器已啟動 (模式: ${mode}, 間隔: ${config.autoSaveInterval}分鐘)`);
         }
     }).catch(err => {
-        console.error('[Cloud Saves] 启动后端定时器前读取配置失败:', err);
+        console.error('[Cloud Saves] 啟動後端定時器前讀取配置失敗:', err);
     });
 }
 
@@ -1111,6 +1160,8 @@ async function init(router) {
                     autoSaveEnabled: config.autoSaveEnabled || false,
                     autoSaveInterval: config.autoSaveInterval || 30,
                     autoSaveTargetTag: config.autoSaveTargetTag || '',
+                    autoSaveMode: config.autoSaveMode || 'overwrite',
+                    autoSaveTimezoneOffset: config.autoSaveTimezoneOffset || 0,
                     has_github_token: !!config.github_token,
                 };
                 res.json(safeConfig);
@@ -1123,7 +1174,7 @@ async function init(router) {
             try {
                 const {
                     repo_url, github_token, display_name, branch, is_authorized,
-                    autoSaveEnabled, autoSaveInterval, autoSaveTargetTag
+                    autoSaveEnabled, autoSaveInterval, autoSaveTargetTag, autoSaveMode, autoSaveTimezoneOffset
                 } = req.body;
                 let currentConfig = await readConfig();
 
@@ -1141,6 +1192,8 @@ async function init(router) {
                 }
                 
                 if (autoSaveTargetTag !== undefined) currentConfig.autoSaveTargetTag = autoSaveTargetTag.trim();
+                if (autoSaveMode !== undefined) currentConfig.autoSaveMode = autoSaveMode;
+                if (autoSaveTimezoneOffset !== undefined) currentConfig.autoSaveTimezoneOffset = parseInt(autoSaveTimezoneOffset) || 0;
 
                 await saveConfig(currentConfig);
                 setupBackendAutoSaveTimer();
@@ -1153,7 +1206,9 @@ async function init(router) {
                     username: currentConfig.username,
                     autoSaveEnabled: currentConfig.autoSaveEnabled,
                     autoSaveInterval: currentConfig.autoSaveInterval,
-                    autoSaveTargetTag: currentConfig.autoSaveTargetTag
+                    autoSaveTargetTag: currentConfig.autoSaveTargetTag,
+                    autoSaveMode: currentConfig.autoSaveMode,
+                    autoSaveTimezoneOffset: currentConfig.autoSaveTimezoneOffset
                 };
                 res.json({ success: true, message: '配置保存成功', config: safeConfig });
             } catch (error) {
@@ -1258,7 +1313,9 @@ async function init(router) {
                     username: config.username,
                     autoSaveEnabled: config.autoSaveEnabled,
                     autoSaveInterval: config.autoSaveInterval,
-                    autoSaveTargetTag: config.autoSaveTargetTag
+                    autoSaveTargetTag: config.autoSaveTargetTag,
+                    autoSaveMode: config.autoSaveMode,
+                    autoSaveTimezoneOffset: config.autoSaveTimezoneOffset
                 };
 
                 res.json({ success: true, message: '授权和配置成功', config: safeConfig });
@@ -1374,7 +1431,7 @@ async function init(router) {
             }
         });
 
-                router.post('/saves/:tagName/overwrite', async (req, res) => {
+        router.post('/saves/:tagName/overwrite', async (req, res) => {
             if (currentOperation) return res.status(409).json({ success: false, message: `正在进行操作: ${currentOperation}` });
             currentOperation = 'overwrite_save';
             const { tagName } = req.params;
@@ -1447,7 +1504,7 @@ async function init(router) {
             }
         });
 
-                // 處理插件檢查更新與拉取
+        // 處理插件檢查更新與拉取
         router.post('/update/check-and-pull', async (req, res) => {
             if (currentOperation) return res.status(409).json({ success: false, message: `正在进行操作: ${currentOperation}` });
             try {
@@ -1495,7 +1552,7 @@ async function init(router) {
     }
 } // 結束 init 函數
 
-// 匯出插件 (這段剛才被截斷了，是擴展能正常運作的關鍵)
+// 匯出插件
 module.exports = {
     info,
     init

--- a/index.js
+++ b/index.js
@@ -1650,7 +1650,7 @@ async function performAutoSave() {
             const day = String(adjustedTime.getUTCDate()).padStart(2, '0');
             const hours = String(adjustedTime.getUTCHours()).padStart(2, '0');
             const minutes = String(adjustedTime.getUTCMinutes()).padStart(2, '0');
-            const saveName = `${year}-${month}-${day} - ${hours}${minutes} (Auto Save)`;
+            const saveName = `Auto Save | ${year}-${month}-${day} | ${hours}${minutes}`;
             
             console.log(`[Cloud Saves Auto] 创建模式: 自动创建新存档 "${saveName}"`);
             

--- a/index.js
+++ b/index.js
@@ -1317,70 +1317,6 @@ async function init(router) {
             }
         });
 
-                // 1. 新增：处理「检查并更新插件」的后端路由
-        router.post('/update/check-and-pull', async (req, res) => {
-            if (currentOperation) return res.status(409).json({ success: false, message: `正在进行操作: ${currentOperation}` });
-            try {
-                currentOperation = 'update_plugin';
-                const git = simpleGit(__dirname); // 检查插件自身的更新，而不是 DATA_DIR
-                
-                const isRepo = await git.checkIsRepo();
-                if (!isRepo) {
-                    return res.json({ success: true, status: 'not_git_repo', message: '无法自动更新：插件似乎不是通过 Git 安装的。' });
-                }
-
-                await git.fetch();
-                const status = await git.status();
-
-                if (status.behind === 0) {
-                    return res.json({ success: true, status: 'latest', message: '插件已是最新版本。' });
-                }
-
-                await git.pull();
-                res.json({ success: true, status: 'updated', message: '插件更新成功！请务必重启 SillyTavern 服务以应用更改。' });
-            } catch (error) {
-                res.status(500).json({ success: false, message: '检查或应用更新时发生意外错误', details: error.message });
-            } finally {
-                currentOperation = null;
-            }
-        });
-
-        // 2. 新增：处理「强制初始化仓库」的后端路由 (另一个也一并修复)
-        router.post('/initialize', async (req, res) => {
-            if (currentOperation) return res.status(409).json({ success: false, message: `正在进行操作: ${currentOperation}` });
-            try {
-                currentOperation = 'initialize_repo';
-                const gitDir = path.join(DATA_DIR, '.git');
-                const hiddenGitDir = path.join(DATA_DIR, GIT_BACKUP_NAME);
-                
-                // 彻底删除被破坏或旧有遗留的仓库文件以强制重建
-                await fs.rm(gitDir, { recursive: true, force: true }).catch(() => {});
-                await fs.rm(hiddenGitDir, { recursive: true, force: true }).catch(() => {});
-                
-                const initResult = await initGitRepo();
-                
-                if (initResult.success) {
-                    res.json({ success: true, message: '仓库强制初始化成功' });
-                } else {
-                    res.status(500).json({ success: false, message: initResult.message, details: initResult.details });
-                }
-            } catch (error) {
-                res.status(500).json({ success: false, message: '初始化仓库时发生意外错误', details: error.message });
-            } finally {
-                currentOperation = null;
-            }
-        });
-
-        // ================= 新增结束 =================
-
-        // 启动后台自动存档计时器
-        setupBackendAutoSaveTimer();
-
-    } catch (error) {
-        console.error('[cloud-saves] 初始化插件期间发生错误:', error);
-    }
-} // 结束 init 函数
-
         router.delete('/saves/:tagName', async (req, res) => {
             if (currentOperation) return res.status(409).json({ success: false, message: `正在进行操作: ${currentOperation}` });
             try {
@@ -1508,6 +1444,46 @@ async function init(router) {
                 res.status(500).json({ success: false, message: '覆盖存档时发生意外错误', details: error.message });
             } finally {
                 currentOperation = null;
+            }
+        });
+
+                // 處理插件檢查更新與拉取
+        router.post('/update/check-and-pull', async (req, res) => {
+            if (currentOperation) return res.status(409).json({ success: false, message: `正在进行操作: ${currentOperation}` });
+            try {
+                const pluginGit = simpleGit(__dirname);
+                const isRepo = await pluginGit.checkIsRepo();
+                
+                if (!isRepo) {
+                    return res.json({ success: true, status: 'not_git_repo' });
+                }
+
+                await pluginGit.fetch();
+                const status = await pluginGit.status();
+
+                if (status.behind === 0) {
+                    return res.json({ success: true, status: 'latest' });
+                }
+
+                await pluginGit.pull();
+                return res.json({ success: true, status: 'updated' });
+            } catch (error) {
+                console.error('[cloud-saves] 检查更新失败:', error);
+                res.status(500).json({ success: false, message: '检查更新过程发生错误', details: error.message });
+            }
+        });
+
+        // 處理強制初始化倉庫 (對應前端的「初始化倉庫」按鈕)
+        router.post('/initialize', async (req, res) => {
+            if (currentOperation) return res.status(409).json({ success: false, message: `正在进行操作: ${currentOperation}` });
+            try {
+                const gitDir = path.join(DATA_DIR, '.git');
+                // 刪除現有的 .git 目錄以實現強制初始化
+                await fs.rm(gitDir, { recursive: true, force: true }).catch(() => {});
+                const result = await initGitRepo();
+                res.json(result);
+            } catch (error) {
+                res.status(500).json({ success: false, message: '强制初始化仓库失败', details: error.message });
             }
         });
 

--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ const info = {
     id: 'cloud-saves',
     name: 'Cloud Saves',
     description: '通过GitHub仓库创建、管理和恢复SillyTavern的云端存档。',
-    version: '1.0.0', // TODO: Consider updating version after refactor
+    version: '1.0.0',
 };
 
 const CONFIG_PATH = path.join(__dirname, 'config.json');
@@ -85,11 +85,105 @@ async function saveConfig(config) {
     await fs.writeFile(CONFIG_PATH, JSON.stringify(config, null, 2));
 }
 
+// 確保 .gitignore 中包含隱藏的 .git 名稱，避免將巢狀 Git 操作紀錄推上 GitHub
+async function ensureGitignoreHidden() {
+    const gitignorePath = path.join(DATA_DIR, '.gitignore');
+    try {
+        let content = '';
+        try { content = await fs.readFile(gitignorePath, 'utf8'); } catch(e){}
+        if (!content.includes('.git_cloud_hidden')) {
+            if (content && !content.endsWith('\n')) content += '\n';
+            content += '.git_cloud_hidden\n';
+            await fs.writeFile(gitignorePath, content, 'utf8');
+            console.log(`[cloud-saves] 自動在 .gitignore 加入了 .git_cloud_hidden`);
+        }
+    } catch(e) {
+        console.error(`[cloud-saves] 更新 .gitignore 失敗:`, e);
+    }
+}
+
+// 暫時將子資料夾(.git)偽裝，這樣 Git 就不會將其作為 Submodule，而是加入裡面所有的原始碼檔案
+async function maskNestedGit(targetPath) {
+    const maskedPaths = [];
+    try {
+        const entries = await fs.readdir(targetPath, { withFileTypes: true });
+        for (const entry of entries) {
+            const entryPath = path.join(targetPath, entry.name);
+            if (entry.isDirectory()) {
+                if (entry.name === '.git') {
+                    const hiddenPath = path.join(targetPath, '.git_cloud_hidden');
+                    try {
+                        await fs.rename(entryPath, hiddenPath);
+                        maskedPaths.push({ original: entryPath, hidden: hiddenPath });
+                    } catch (e) {
+                        console.error(`[cloud-saves] 無法偽裝 ${entryPath}:`, e);
+                    }
+                } else if (entry.name !== '.git_cloud_hidden') {
+                    const subMasked = await maskNestedGit(entryPath);
+                    maskedPaths.push(...subMasked);
+                }
+            }
+        }
+    } catch (error) {
+        if (error.code !== 'ENOENT') {
+            console.error(`[cloud-saves] 遞迴偽裝 .git 資料夾時發生錯誤 (${targetPath}):`, error);
+        }
+    }
+    return maskedPaths;
+}
+
+// 在操作完成後將其還原為真正的 .git 資料夾
+async function unmaskNestedGit(maskedPaths) {
+    for (const paths of maskedPaths) {
+        try {
+            await fs.rename(paths.hidden, paths.original);
+        } catch (e) {
+            console.error(`[cloud-saves] 無法還原 ${paths.hidden}:`, e);
+        }
+    }
+}
+
+// 從 index 緩存中清除可能早已留下的 Gitlink 舊參照（使得重新索引能以實際檔案型態備份）
+async function removeGitlinksFromIndex(git, prefix) {
+    console.log(`[cloud-saves] 正在檢查是否有舊 Gitlink 參照: ${prefix}`);
+    const prefixPath = prefix.endsWith('/') ? prefix : prefix + '/';
+
+    try {
+        const lsFilesOutput = await git.raw('ls-files', '--stage');
+        if (!lsFilesOutput) return;
+
+        const lines = lsFilesOutput.trim().split('\n');
+        const gitlinksToRemove = [];
+
+        for (const line of lines) {
+            const parts = line.split(/\s+/);
+            if (parts.length >= 4) {
+                const mode = parts[0];
+                const filePath = parts.slice(3).join(' ');
+                if (mode === '160000' && filePath.startsWith(prefixPath)) {
+                    gitlinksToRemove.push(filePath);
+                }
+            }
+        }
+
+        if (gitlinksToRemove.length > 0) {
+            console.log(`[cloud-saves] 正在移除 ${gitlinksToRemove.length} 個擴展 Gitlink，改為完整追蹤實體檔案...`);
+            for (const filePath of gitlinksToRemove) {
+                try {
+                     await git.raw('rm', '--cached', '--ignore-unmatch', filePath);
+                } catch (rmError) {}
+            }
+        }
+    } catch (error) {
+        console.error(`[cloud-saves] 修正 Gitlink 時發生錯誤:`, error);
+    }
+}
+
 async function getGitInstance(cwd = DATA_DIR) {
     const options = {
         baseDir: cwd,
         binary: 'git',
-        maxConcurrentProcesses: 6, // Default
+        maxConcurrentProcesses: 6,
     };
     const git = simpleGit(options);
     const config = await readConfig();
@@ -105,14 +199,12 @@ async function getGitInstance(cwd = DATA_DIR) {
                 authUrl = originalUrl.replace('https://', `https://x-access-token:${config.github_token}@`);
             }
             if (origin && origin.refs.push !== authUrl) {
-                 console.log(`[cloud-saves] Configuring remote 'origin' with auth URL for ${path.basename(cwd)}`);
                  await git.remote(['set-url', 'origin', authUrl]);
             } else if (!origin && originalUrl) {
-                 console.log(`[cloud-saves] Adding remote 'origin' with auth URL for ${path.basename(cwd)}`);
                  await git.addRemote('origin', authUrl);
             }
         } catch (error) {
-            console.warn(`[cloud-saves] Failed to configure authenticated remote for ${path.basename(cwd)}:`, error.message);
+            console.warn(`[cloud-saves] 無法配置授權遠端 URL:`, error.message);
         }
     }
     
@@ -141,7 +233,7 @@ async function isGitInitialized() {
         return await git.checkIsRepo();
     } catch (error) {
         if (error.code !== 'ENOENT') {
-            console.error("[cloud-saves] Error checking git initialization:", error);
+            console.error("[cloud-saves] 檢查 git 初始化發生錯誤:", error);
         }
         return false;
     }
@@ -158,196 +250,55 @@ async function addGitkeepRecursively(directory) {
                 hasGitkeep = true;
             }
             if (entry.isDirectory()) {
-                // Skip .git directory itself
                 if (entry.name !== '.git') {
                     subDirectories.push(path.join(directory, entry.name));
                 }
             }
         }
 
-        // If no .gitkeep found in the current directory, create one
         if (!hasGitkeep) {
             const gitkeepPath = path.join(directory, '.gitkeep');
             try {
-                // Check if it exists first, might have been created by another process
                 await fs.access(gitkeepPath);
             } catch (e) {
                 try {
-                    await fs.writeFile(gitkeepPath, ''); // Create empty file
-                    console.log(`[cloud-saves] Created .gitkeep in ${path.relative(DATA_DIR, directory) || '.'}`);
-                } catch (writeError) {
-                    console.error(`[cloud-saves] Failed to create .gitkeep in ${path.relative(DATA_DIR, directory) || '.'}:`, writeError);
-                }
+                    await fs.writeFile(gitkeepPath, '');
+                } catch (writeError) {}
             }
         }
 
-        // Recursively call for subdirectories
         for (const subDir of subDirectories) {
             await addGitkeepRecursively(subDir);
         }
-
-    } catch (error) {
-        // Log error if directory doesn't exist during recursion, but don't stop the whole process
-        if (error.code !== 'ENOENT') {
-             console.error(`[cloud-saves] Error processing directory ${path.relative(DATA_DIR, directory) || '.'} for .gitkeep:`, error);
-        }
-    }
+    } catch (error) {}
 }
 
-async function removeNestedGitFiles(targetPath) {
-    try {
-        const entries = await fs.readdir(targetPath, { withFileTypes: true });
-        for (const entry of entries) {
-            const entryPath = path.join(targetPath, entry.name);
-            if (entry.isDirectory()) {
-                if (entry.name === '.git') {
-                    try {
-                        console.warn(`[cloud-saves] Removing nested .git directory: ${entryPath}`);
-                        await fs.rm(entryPath, { recursive: true, force: true });
-                    } catch (rmError) {
-                        console.error(`[cloud-saves] Failed to remove nested .git directory ${entryPath}:`, rmError);
-                    }
-                } else {
-                    // Recursively process other subdirectories within the target path
-                    await removeNestedGitFiles(entryPath);
-                }
-            } else if (entry.isFile() && entry.name === '.gitignore') {
-                try {
-                    console.warn(`[cloud-saves] Removing nested .gitignore file: ${entryPath}`);
-                    await fs.rm(entryPath, { force: true });
-                } catch (rmError) {
-                    console.error(`[cloud-saves] Failed to remove nested .gitignore file ${entryPath}:`, rmError);
-                }
-            }
-        }
-    } catch (error) {
-         // If the targetPath itself doesn't exist, just log it and return gracefully.
-         if (error.code === 'ENOENT') {
-             console.log(`[cloud-saves] Directory ${targetPath} not found for nested git removal, skipping.`);
-             return;
-         }
-        console.error(`[cloud-saves] Error processing directory ${targetPath} for nested git file removal:`, error);
-    }
-}
-
-// NEW: Helper function to fix gitlink entries in the index for a specific path prefix
-async function fixGitlinkEntries(prefix) {
-    console.log(`[cloud-saves] Checking index for gitlink entries under prefix: ${prefix}`);
-    const git = simpleGit(DATA_DIR); // Use instance pointing to DATA_DIR
-    const prefixPath = prefix.endsWith('/') ? prefix : prefix + '/'; // Ensure trailing slash for path matching
-
-    try {
-        // Get the index content
-        // Format: <mode> <hash> <stage>\t<path>
-        const lsFilesOutput = await git.raw('ls-files', '--stage');
-        if (!lsFilesOutput) {
-            console.log('[cloud-saves] Index is empty, no gitlink entries to fix.');
-            return;
-        }
-
-        const lines = lsFilesOutput.trim().split('\n');
-        const gitlinksToRemove = [];
-
-        for (const line of lines) {
-            // Careful parsing: split by space/tab, path is after tab
-            const parts = line.split(/\s+/); // Split by whitespace
-            if (parts.length >= 4) {
-                const mode = parts[0];
-                const filePath = parts.slice(3).join(' '); // Rejoin path if it contains spaces
-
-                // Check if it's a gitlink (submodule) and within the target prefix
-                if (mode === '160000' && filePath.startsWith(prefixPath)) {
-                    console.log(`[cloud-saves] Found gitlink entry to remove from index: ${filePath}`);
-                    gitlinksToRemove.push(filePath);
-                }
-            }
-        }
-
-        if (gitlinksToRemove.length === 0) {
-            console.log(`[cloud-saves] No gitlink entries found under ${prefixPath}.`);
-            return;
-        }
-
-        // Remove the identified gitlink entries from the index
-        console.log(`[cloud-saves] Removing ${gitlinksToRemove.length} gitlink entries from index...`);
-        // Use raw command for rm --cached as simple-git might not directly support removing only from index
-        // Use --ignore-unmatch for robustness
-        for (const filePath of gitlinksToRemove) {
-            try {
-                 // Important: Need to quote paths in case they contain spaces
-                 // Use raw for precise control over 'rm --cached'
-                 await git.raw('rm', '--cached', '--ignore-unmatch', filePath);
-                 console.log(`[cloud-saves] Removed ${filePath} from index.`);
-            } catch (rmError) {
-                 // Log error but continue processing other entries
-                 console.error(`[cloud-saves] Failed to remove ${filePath} from index:`, rmError);
-            }
-        }
-        console.log('[cloud-saves] Finished removing gitlink entries from index.');
-
-    } catch (error) {
-        console.error(`[cloud-saves] Error fixing gitlink entries under ${prefix}:`, error);
-        // Decide if this should be a fatal error for initGitRepo?
-        // For now, just log it. Subsequent 'git add' might still work partially.
-        throw new Error(`Failed to fix gitlink entries: ${error.message}`); // Re-throw to signal potential issue
-    }
-}
-
-// 初始化Git仓库 (MODIFIED to include fixing gitlink entries)
 async function initGitRepo() {
     if (await isGitInitialized()) {
         console.log('[cloud-saves] Git repository already initialized in data directory.');
-        return { success: true, message: 'Git仓库已在data目录中初始化' };
+        await ensureGitignoreHidden();
+        return { success: true, message: 'Git倉庫已在data目錄中初始化' };
     }
 
-    console.log('[cloud-saves] 正在data目录中初始化Git仓库:', DATA_DIR);
+    console.log('[cloud-saves] 正在data目錄中初始化Git倉庫:', DATA_DIR);
     try {
         const git = simpleGit(DATA_DIR);
         await git.init();
         console.log('[cloud-saves] git init 成功');
 
-        // --- Step 1: Remove nested .git and .gitignore in extensions ---
-        const extensionsPath = path.join(DATA_DIR, 'default-user', 'extensions');
-        console.warn(`[cloud-saves] WARNING: Removing nested .git/.gitignore within ${extensionsPath} ...`);
-        try {
-            await fs.access(extensionsPath);
-            await removeNestedGitFiles(extensionsPath);
-            console.log(`[cloud-saves] Finished removing nested git files within ${extensionsPath}.`);
-        } catch (error) {
-            if (error.code === 'ENOENT') {
-                console.log(`[cloud-saves] Extensions directory (${extensionsPath}) not found, skipping nested git removal.`);
-            } else {
-                 console.error(`[cloud-saves] Error accessing extensions directory for cleanup: ${error}`);
-            }
-        }
-
-        // --- Step 2: Fix gitlink entries in the index for extensions path ---
-        const extensionsRelativePath = path.relative(DATA_DIR, extensionsPath).replace(/\\/g, '/'); // Get relative path like 'default-user/extensions'
-        try {
-            await fixGitlinkEntries(extensionsRelativePath);
-        } catch (fixError) {
-             // Log the error but potentially continue, as add .gitkeep might still be useful
-             console.error('[cloud-saves] WARNING: Failed during gitlink fixing step, proceeding with .gitkeep addition.', fixError);
-        }
-        // --- END Step 2 ---
-
-        // --- Step 3: Add .gitkeep to ensure directory structure ---
         console.log('[cloud-saves] Adding .gitkeep files to ensure all directory tracking...');
         await addGitkeepRecursively(DATA_DIR);
-        console.log('[cloud-saves] Finished adding .gitkeep files.');
 
-        // --- Step 4: Create the main .gitignore ---
         try {
             const gitignorePath = path.join(DATA_DIR, '.gitignore');
-            // Corrected content: Use !* to un-ignore everything first, then specify exclusions.
-            const gitignoreContent = "# Ensure data directory contents are tracked, overriding parent ignores.\n!*\n\n# Ignore specific subdirectories within data\n_uploads/\n_cache/\n_storage/\n_webpack/\n";
+            const gitignoreContent = "# Ensure data directory contents are tracked, overriding parent ignores.\n!*\n\n# Ignore specific subdirectories within data\n_uploads/\n_cache/\n_storage/\n_webpack/\n.git_cloud_hidden\n";
             await fs.writeFile(gitignorePath, gitignoreContent, 'utf8');
-            console.log(`[cloud-saves] 已成功创建/更新主 ${gitignorePath}`);
+            console.log(`[cloud-saves] 已成功創建主 ${gitignorePath}`);
         } catch (gitignoreError) {
-            console.error(`[cloud-saves] 创建主 ${path.join(DATA_DIR, '.gitignore')} 文件失败:`, gitignoreError);
+            console.error(`[cloud-saves] 創建主 .gitignore 文件失敗:`, gitignoreError);
         }
 
-        return { success: true, message: 'Git仓库初始化成功，嵌套git文件已清理，索引已修正，并添加了.gitkeep文件' }; // Updated message
+        return { success: true, message: 'Git倉庫初始化成功，並添加了.gitkeep文件' };
     } catch (error) {
         return handleGitError(error, '初始化Git仓库');
     }
@@ -367,14 +318,12 @@ async function configureRemote(repoUrl) {
 
         if (origin) {
             if (origin.refs.push !== authUrl) {
-                console.log('[cloud-saves] Updating remote origin URL.');
                 await git.remote(['set-url', 'origin', authUrl]);
             }
         } else {
-            console.log('[cloud-saves] Adding remote origin.');
             await git.addRemote('origin', authUrl);
         }
-        return { success: true, message: '远程仓库配置检查/更新成功' };
+        return { success: true, message: '远程仓库配置成功' };
     } catch (error) {
         return handleGitError(error, '配置远程仓库');
     }
@@ -383,7 +332,8 @@ async function configureRemote(repoUrl) {
 async function createSave(name, description) {
     try {
         currentOperation = 'create_save';
-        console.log(`[cloud-saves] 正在创建新存档: ${name}, 描述: ${description}`);
+        console.log(`[cloud-saves] 正在創建新存檔: ${name}, 描述: ${description}`);
+        await ensureGitignoreHidden();
         const config = await readConfig();
         const git = await getGitInstance();
         const branchToPush = config.branch || DEFAULT_BRANCH;
@@ -394,40 +344,46 @@ async function createSave(name, description) {
         const tagMessage = description || `存档: ${name}`;
         const fullTagMessage = `${tagMessage}\nLast Updated: ${nowTimestamp}`;
 
-        await git.add('.');
-        const status = await git.status();
-        let commitNeeded = !status.isClean();
+        const extensionsPath = path.join(DATA_DIR, 'default-user', 'extensions');
+        let maskedPaths = [];
+        let commitNeeded = false;
 
-        if (commitNeeded) {
-            console.log('[cloud-saves] 执行提交...');
-            try {
-                await git.commit(`存档: ${name}`);
-            } catch (commitError) {
-                if (commitError.message.includes('nothing to commit')) {
-                     console.log('[cloud-saves] 提交时无更改。');
-                     commitNeeded = false;
-                } else {
-                    throw commitError;
+        try {
+            maskedPaths = await maskNestedGit(extensionsPath);
+            await removeGitlinksFromIndex(git, 'default-user/extensions/');
+
+            await git.add('.');
+            const status = await git.status();
+            commitNeeded = !status.isClean();
+
+            if (commitNeeded) {
+                console.log('[cloud-saves] 已掃描完成，執行提交...');
+                try {
+                    await git.commit(`存档: ${name}`);
+                } catch (commitError) {
+                    if (commitError.message.includes('nothing to commit')) {
+                         commitNeeded = false;
+                    } else {
+                        throw commitError;
+                    }
                 }
             }
+        } finally {
+            await unmaskNestedGit(maskedPaths);
         }
 
-        console.log('[cloud-saves] 创建标签...');
+        console.log('[cloud-saves] 創建標籤並推送...');
         await git.addAnnotatedTag(tagName, fullTagMessage);
 
-        console.log('[cloud-saves] 推送更改...');
         const currentBranchStatus = await git.branch();
         const currentBranch = currentBranchStatus.current;
 
         if (commitNeeded && currentBranch === branchToPush && !currentBranchStatus.detached) {
-            console.log(`[cloud-saves] 推送分支: ${currentBranch}`);
             try {
                  await git.push('origin', currentBranch);
             } catch (pushError) {
-                console.warn(`[cloud-saves] 推送分支 ${currentBranch} 失败:`, pushError.message);
+                console.warn(`[cloud-saves] 推送分支錯誤:`, pushError.message);
             }
-        } else if (commitNeeded) {
-             console.log(`[cloud-saves] 当前不在配置的分支 (${branchToPush}) 或处于 detached HEAD，跳过推送提交。当前: ${currentBranch || 'Detached'}`);
         }
 
         await git.push(['origin', tagName]);
@@ -463,17 +419,13 @@ async function listSaves() {
         console.log('[cloud-saves] 获取存档列表');
         const git = await getGitInstance();
 
-        // Fetch tags from origin, FORCE update local refs, and PRUNE deleted tags
         console.log('[cloud-saves] Fetching and pruning remote tags...');
         await git.fetch(['origin', '--tags', '--force', '--prune-tags']);
 
-        // Get tags with details (lists local tags after pruning)
         const formatString = "%(refname:short)%00%(creatordate:iso)%00%(taggername)%00%(subject)%00%(contents)";
         const tagOutput = await git.raw('tag', '-l', 'save_*', '--sort=-creatordate', `--format=${formatString}`);
 
-        if (!tagOutput) {
-             return { success: true, saves: [] };
-        }
+        if (!tagOutput) return { success: true, saves: [] };
 
         const saves = tagOutput.trim().split('\n').filter(Boolean).map(line => {
             const parts = line.split('\0');
@@ -507,7 +459,6 @@ async function listSaves() {
                     const encodedName = tagNameMatch[1];
                     name = Buffer.from(encodedName, 'base64url').toString('utf8');
                 } catch (decodeError) {
-                    console.warn(`[cloud-saves] 解码存档名称失败 (${tagName}):`, decodeError);
                     name = tagNameMatch[1];
                 }
             }
@@ -534,7 +485,7 @@ async function listSaves() {
 async function loadSave(tagName) {
     try {
         currentOperation = 'load_save';
-        console.log(`[cloud-saves] 正在加载存档: ${tagName}`);
+        console.log(`[cloud-saves] 正在載入存檔: ${tagName}`);
         const git = await getGitInstance();
         const config = await readConfig();
 
@@ -544,30 +495,32 @@ async function loadSave(tagName) {
             return { success: false, message: '找不到指定的存档标签' };
         }
 
-        const status = await git.status();
+        const extensionsPath = path.join(DATA_DIR, 'default-user', 'extensions');
+        let maskedPaths = [];
         let stashCreated = false;
-        if (!status.isClean()) {
-            console.log('[cloud-saves] 检测到未保存的更改，在回档前创建临时保存点');
-            const stashResult = await git.stash(['push', '-u', '-m', 'Temporary stash before loading save']);
-            stashCreated = stashResult && !stashResult.includes('No local changes to save');
-             if (stashCreated) {
-                 console.log('[cloud-saves] 临时保存点创建成功');
-                 config.has_temp_stash = true;
-             } else {
-                 console.warn('[cloud-saves] 创建临时保存点失败或没有更改需要保存');
-                 config.has_temp_stash = false;
-             }
-        } else {
-             config.has_temp_stash = false;
-        }
-        
-        const commit = await git.revparse([tagName]);
-        if (!commit) {
-            if(stashCreated) await git.stash(['pop']);
-             return { success: false, message: '获取存档提交哈希失败' };
-        }
 
-        await git.checkout(commit);
+        try {
+            maskedPaths = await maskNestedGit(extensionsPath);
+
+            const status = await git.status();
+            if (!status.isClean()) {
+                console.log('[cloud-saves] 检测到未保存的更改，在回档前创建临时保存点');
+                const stashResult = await git.stash(['push', '-u', '-m', 'Temporary stash before loading save']);
+                stashCreated = stashResult && !stashResult.includes('No local changes to save');
+                config.has_temp_stash = stashCreated;
+            } else config.has_temp_stash = false;
+            
+            const commit = await git.revparse([tagName]);
+            if (!commit) {
+                if(stashCreated) await git.stash(['pop']);
+                return { success: false, message: '获取存档提交哈希失败' };
+            }
+
+            await git.checkout(commit);
+
+        } finally {
+            await unmaskNestedGit(maskedPaths);
+        }
 
         config.current_save = {
             tag: tagName,
@@ -585,15 +538,11 @@ async function loadSave(tagName) {
             const cfg = await readConfig();
             if (cfg.has_temp_stash) {
                 const git = await getGitInstance();
-                console.warn("[cloud-saves] Load failed, attempting to pop temporary stash...");
                 await git.stash(['pop']);
                 cfg.has_temp_stash = false;
                 await saveConfig(cfg);
-                console.warn("[cloud-saves] Temporary stash popped after load failure.");
             }
-        } catch (popError) {
-              console.error("[cloud-saves] Failed to pop temporary stash after load error:", popError);
-        }
+        } catch (popError) {}
         return handleGitError(error, `加载存档 ${tagName}`);
     } finally {
         currentOperation = null;
@@ -607,19 +556,11 @@ async function deleteSave(tagName) {
         const git = await getGitInstance();
 
         await git.tag(['-d', tagName]);
-        console.log(`[cloud-saves] 本地标签 ${tagName} 已删除 (或不存在)`);
-
-        let remoteDeleteSuccess = false;
+        
         try {
             await git.push(['origin', `:refs/tags/${tagName}`]);
-            console.log(`[cloud-saves] 远程标签 ${tagName} 已删除`);
-            remoteDeleteSuccess = true;
         } catch (pushError) {
-            if (pushError.message.includes('remote ref does not exist') || pushError.message.includes('deletion of') ) {
-                console.log(`[cloud-saves] 远程标签 ${tagName} 不存在或已被删除`);
-                remoteDeleteSuccess = true;
-            } else {
-                 console.warn(`[cloud-saves] 删除远程标签 ${tagName} 失败:`, pushError.message);
+            if (!pushError.message.includes('remote ref does not exist') && !pushError.message.includes('deletion of') ) {
                  const config = await readConfig();
                  if (config.current_save && config.current_save.tag === tagName) {
                      config.current_save = null;
@@ -673,19 +614,14 @@ async function renameSave(oldTagName, newName, description) {
         const fullNewMessage = `${newDescription}\nLast Updated: ${nowTimestamp}`;
 
         if (oldDecodedName === newName) {
-            console.log(`[cloud-saves] 名称未变，仅更新标签描述和时间戳: ${oldTagName}`);
             await git.tag(['-a', '-f', oldTagName, '-m', fullNewMessage, commit]);
             await git.push(['origin', oldTagName, '--force']);
              return { success: true, message: '存档描述和更新时间已更新', oldTag: oldTagName, newTag: oldTagName, newName: newName };
         } else {
-             console.log(`[cloud-saves] 名称已更改，执行完整重命名流程...`);
              const encodedNewName = Buffer.from(newName).toString('base64url');
              const newTagName = `save_${Date.now()}_${encodedNewName}`;
 
-             console.log(`[cloud-saves] 创建新标签: ${newTagName}`);
              await git.addAnnotatedTag(newTagName, fullNewMessage, commit);
-
-             console.log(`[cloud-saves] 推送新标签: ${newTagName}`);
              try {
                 await git.push('origin', newTagName);
              } catch (pushError) {
@@ -693,17 +629,10 @@ async function renameSave(oldTagName, newName, description) {
                   throw pushError;
              }
 
-             console.log(`[cloud-saves] 删除旧本地标签: ${oldTagName}`);
              await git.tag(['-d', oldTagName]);
-
-             console.log(`[cloud-saves] 删除旧远程标签: ${oldTagName}`);
              try {
                  await git.push(['origin', `:refs/tags/${oldTagName}`]);
-             } catch(deleteRemoteError) {
-                  if (!deleteRemoteError.message.includes('remote ref does not exist')) {
-                      console.warn(`[cloud-saves] 删除旧远程标签 ${oldTagName} 失败:`, deleteRemoteError.message);
-                  }
-             }
+             } catch (e) {}
 
             if (config.current_save && config.current_save.tag === oldTagName) {
                 config.current_save.tag = newTagName;
@@ -722,7 +651,6 @@ async function renameSave(oldTagName, newName, description) {
 async function getSaveDiff(ref1, ref2) {
     try {
         currentOperation = 'get_save_diff';
-        console.log(`[cloud-saves] 获取差异: ${ref1} <-> ${ref2}`);
         const git = simpleGit(DATA_DIR);
         const emptyTreeHash = '4b825dc642cb6eb9a060e54bf8d69288fbee4904';
 
@@ -730,12 +658,10 @@ async function getSaveDiff(ref1, ref2) {
             await git.revparse(['--verify', ref1]);
         } catch (error) {
             if ((ref1.endsWith('^') || ref1.endsWith('~1')) && error.message.includes('unknown revision')) {
-                console.warn(`[cloud-saves] 无法解析引用 ${ref1}，可能为初始提交的父提交。尝试与空树比较。`);
                 ref1 = emptyTreeHash;
             } else if (ref1 === emptyTreeHash) {
                 
-            }
-            else {
+            } else {
                  return { success: false, message: `找不到或无效的引用: ${ref1}`, details: error.message };
             }
         }
@@ -748,7 +674,6 @@ async function getSaveDiff(ref1, ref2) {
         let diffOutput;
          try {
              if (ref1 === emptyTreeHash) {
-                  console.log(`[cloud-saves] 与空树比较 (${ref2})，使用 'git ls-tree' 显示初始提交内容。`);
                  const lsTreeOutput = await git.raw('ls-tree', '-r', '--name-only', ref2);
                  if (!lsTreeOutput) return { success: true, changedFiles: [] };
                  changedFiles = lsTreeOutput.trim().split('\n').filter(Boolean).map(fileName => ({
@@ -789,7 +714,17 @@ async function getGitStatus() {
 
         let status = null;
         if (isInitialized) {
-            status = await git.status();
+            if (!currentOperation) { // 防止與備份時的 Mask 衝突
+                const extensionsPath = path.join(DATA_DIR, 'default-user', 'extensions');
+                let maskedPaths = await maskNestedGit(extensionsPath);
+                try {
+                    status = await git.status();
+                } finally {
+                    await unmaskNestedGit(maskedPaths);
+                }
+            } else {
+                status = await git.status();
+            }
         }
 
         let currentBranch = null;
@@ -799,9 +734,7 @@ async function getGitStatus() {
                  const branchSummary = await git.branch();
                  currentBranch = branchSummary.current;
                  isDetached = branchSummary.detached;
-             } catch (branchError) {
-                  console.warn('[cloud-saves] 获取分支信息失败:', branchError.message);
-             }
+             } catch (branchError) {}
         }
 
         const config = await readConfig();
@@ -818,9 +751,7 @@ async function getGitStatus() {
         };
         
         return formattedStatus;
-
     } catch (error) {
-        console.error('获取Git状态时出错:', error);
         throw handleGitError(error, '获取Git状态');
     }
 }
@@ -829,19 +760,30 @@ async function hasUnsavedChanges() {
     try {
         const git = simpleGit(DATA_DIR);
         if (!await isGitInitialized()) return false;
-        const status = await git.status();
-        return !status.isClean();
+
+        let isClean = true;
+        if (!currentOperation) {
+            const extensionsPath = path.join(DATA_DIR, 'default-user', 'extensions');
+            let maskedPaths = await maskNestedGit(extensionsPath);
+            try {
+                const status = await git.status();
+                isClean = status.isClean();
+            } finally {
+                await unmaskNestedGit(maskedPaths);
+            }
+        } else {
+            const status = await git.status();
+            isClean = status.isClean();
+        }
+        return !isClean;
     } catch (error) {
-         console.error('[cloud-saves]检查未保存更改时出错:', error);
          return false;
     }
 }
 
 async function checkTempStash() {
     const config = await readConfig();
-    if (!config.has_temp_stash) {
-        return { exists: false };
-    }
+    if (!config.has_temp_stash) return { exists: false };
 
     try {
         const git = simpleGit(DATA_DIR);
@@ -861,8 +803,7 @@ async function checkTempStash() {
 
         return { exists: true };
     } catch (error) {
-        console.error('[cloud-saves] Error checking stash list:', error);
-        return { exists: config.has_temp_stash, error: 'Failed to check stash list' };
+        return { exists: config.has_temp_stash };
     }
 }
 
@@ -874,44 +815,23 @@ async function applyTempStash() {
 
     try {
         const git = simpleGit(DATA_DIR);
-        console.log('[cloud-saves][DEBUG] Checking stash list in applyTempStash...');
         const stashList = await git.stashList();
-        console.log('[cloud-saves][DEBUG] Stash list result:', JSON.stringify(stashList, null, 2));
 
         const stashMessageToFind = 'Temporary stash before loading save';
-        // Use findIndex to get the index of the stash
         const stashIndex = stashList.all.findIndex(s => s.message && s.message.includes(stashMessageToFind));
 
-        // DEBUG LOG: Print the found index
-        console.log(`[cloud-saves][DEBUG] Found tempStash index: ${stashIndex}`);
-
-        if (stashIndex === -1) { // Check if index was found
-            console.warn('[cloud-saves] Temporary stash message not found in list. Clearing flag.');
+        if (stashIndex === -1) {
             config.has_temp_stash = false;
             await saveConfig(config);
-            return { success: false, message: `Stash with message "${stashMessageToFind}" not found in stash list` };
+            return { success: false, message: `Stash not found in list` };
         }
 
-        // Construct the stash reference using the index
         const stashRef = `stash@{${stashIndex}}`;
-
-        // DEBUG LOG: Print the constructed stashRef value
-        console.log(`[cloud-saves][DEBUG] Constructed stash ref to apply/drop: ${stashRef}`);
-
-        // No need for undefined check anymore as we construct it directly
-
-        console.log(`[cloud-saves] Applying temporary stash: ${stashRef}`);
         await git.stash(['apply', stashRef]);
 
-        console.log(`[cloud-saves] Dropping temporary stash: ${stashRef}`);
         try {
             await git.stash(['drop', stashRef]);
-        } catch (dropError) {
-            console.error(`[cloud-saves] Failed to drop stash ${stashRef} after applying:`, dropError);
-            config.has_temp_stash = false; // Still clear flag maybe? Or leave it? Let's clear it and return warning.
-            await saveConfig(config);
-            return handleGitError(dropError, `应用成功但丢弃Stash ${stashRef} 失败`);
-        }
+        } catch (dropError) {}
 
         config.has_temp_stash = false;
         await saveConfig(config);
@@ -930,33 +850,18 @@ async function discardTempStash() {
 
     try {
         const git = simpleGit(DATA_DIR);
-        console.log('[cloud-saves][DEBUG] Checking stash list in discardTempStash...');
         const stashList = await git.stashList();
-        console.log('[cloud-saves][DEBUG] Stash list result:', JSON.stringify(stashList, null, 2));
 
         const stashMessageToFind = 'Temporary stash before loading save';
-        // Use findIndex to get the index of the stash
         const stashIndex = stashList.all.findIndex(s => s.message && s.message.includes(stashMessageToFind));
 
-        // DEBUG LOG: Print the found index
-        console.log(`[cloud-saves][DEBUG] Found tempStash index: ${stashIndex}`);
-
-        if (stashIndex === -1) { // Check if index was found
-            console.warn('[cloud-saves] Temporary stash message not found in list. Clearing flag.');
+        if (stashIndex === -1) {
             config.has_temp_stash = false;
             await saveConfig(config);
-            return { success: true, message: `Stash with message "${stashMessageToFind}" already gone or not found` };
+            return { success: true, message: `Stash already gone` };
         }
 
-        // Construct the stash reference using the index
         const stashRef = `stash@{${stashIndex}}`;
-
-        // DEBUG LOG: Print the constructed stashRef value
-        console.log(`[cloud-saves][DEBUG] Constructed stash ref to drop: ${stashRef}`);
-
-        // No need for undefined check
-
-        console.log(`[cloud-saves] Dropping temporary stash: ${stashRef}`);
         await git.stash(['drop', stashRef]);
 
         config.has_temp_stash = false;
@@ -969,17 +874,14 @@ async function discardTempStash() {
 }
 
 async function performAutoSave() {
-    if (currentOperation) {
-        console.log(`[Cloud Saves Auto] 跳过自动存档，当前有操作正在进行: ${currentOperation}`);
-        return;
-    }
+    if (currentOperation) return;
     currentOperation = 'auto_save';
+    
     let config;
     let git;
     try {
         config = await readConfig();
         if (!config.is_authorized || !config.autoSaveEnabled || !config.autoSaveTargetTag) {
-            console.log('[Cloud Saves Auto] 自动存档条件不满足，跳过。');
             currentOperation = null;
             return;
         }
@@ -992,56 +894,44 @@ async function performAutoSave() {
         let originalDescription = `Auto Save Overwrite: ${targetTag}`;
         try {
              const tagInfoRaw = await git.raw('tag', '-n1', '-l', targetTag, '--format=%(contents)');
-             if (tagInfoRaw) {
-                 originalDescription = tagInfoRaw.trim().split('\n')[0];
-             }
-        } catch (tagInfoError) {
-             console.warn(`[Cloud Saves Auto] 获取旧标签 ${targetTag} 信息失败，将使用默认描述。`, tagInfoError.message);
-        }
+             if (tagInfoRaw) originalDescription = tagInfoRaw.trim().split('\n')[0];
+        } catch (tagInfoError) {}
 
-        await git.add('.');
-        const status = await git.status();
-        const hasChanges = !status.isClean();
+        await ensureGitignoreHidden();
+        const extensionsPath = path.join(DATA_DIR, 'default-user', 'extensions');
+        let maskedPaths = [];
         let newCommitHash;
 
-        if (hasChanges) {
-            const commitMessage = `Auto Save Overwrite: ${targetTag}`;
-            try {
-                const commitResult = await git.commit(commitMessage);
-                 newCommitHash = commitResult.commit;
-                 console.log('[Cloud Saves Auto] 新自动存档提交哈希:', newCommitHash);
+        try {
+            maskedPaths = await maskNestedGit(extensionsPath);
+            await removeGitlinksFromIndex(git, 'default-user/extensions/');
+
+            await git.add('.');
+            const status = await git.status();
+            const hasChanges = !status.isClean();
+
+            if (hasChanges) {
+                const commitMessage = `Auto Save Overwrite: ${targetTag}`;
                 try {
-                    await git.push('origin', branchToUse);
-                } catch (pushCommitError) {
-                    console.warn(`[Cloud Saves Auto] 推送自动存档提交到分支 ${branchToUse} 失败:`, pushCommitError.message);
+                    const commitResult = await git.commit(commitMessage);
+                     newCommitHash = commitResult.commit;
+                    try { await git.push('origin', branchToUse); } catch (pushCommitError) {}
+                } catch (commitError) {
+                    if (commitError.message.includes('nothing to commit')) {
+                        newCommitHash = await git.revparse('HEAD');
+                    } else throw commitError;
                 }
-            } catch (commitError) {
-                if (commitError.message.includes('nothing to commit')) {
-                    console.log('[Cloud Saves Auto] 自动存档时无实际更改可提交，将使用当前 HEAD');
-                    newCommitHash = await git.revparse('HEAD');
-                } else {
-                     throw commitError;
-                }
+            } else {
+                newCommitHash = await git.revparse('HEAD');
             }
-        } else {
-            console.log('[Cloud Saves Auto] 自动存档时无实际更改可提交，将使用当前 HEAD');
-            newCommitHash = await git.revparse('HEAD');
+        } finally {
+            await unmaskNestedGit(maskedPaths);
         }
 
-        if (!newCommitHash) {
-            throw new Error('无法确定用于自动存档的提交哈希');
-        }
+        if (!newCommitHash) throw new Error('无法确定用于自动存档的提交哈希');
 
-        try {
-             await git.tag(['-d', targetTag]);
-        } catch (delLocalErr) { /* Ignore if local doesn't exist */ }
-        try {
-            await git.push(['origin', `:refs/tags/${targetTag}`]);
-        } catch (delRemoteErr) {
-            if (!delRemoteErr.message.includes('remote ref does not exist')) {
-                 console.warn(`[Cloud Saves Auto] 删除远程旧标签 ${targetTag} 时遇到问题:`, delRemoteErr.message);
-            }
-        }
+        try { await git.tag(['-d', targetTag]); } catch (delLocalErr) {}
+        try { await git.push(['origin', `:refs/tags/${targetTag}`]); } catch (delRemoteErr) {}
 
         const nowTimestampOverwrite = new Date().toISOString();
         const fullTagMessageOverwrite = `${originalDescription}\nLast Updated: ${nowTimestampOverwrite}`;
@@ -1053,7 +943,6 @@ async function performAutoSave() {
              await git.tag(['-d', targetTag]);
              throw pushTagError;
         }
-
         console.log(`[Cloud Saves Auto] 成功自动覆盖存档: ${targetTag}`);
 
     } catch (error) {
@@ -1065,23 +954,15 @@ async function performAutoSave() {
 
 function setupBackendAutoSaveTimer() {
     if (autoSaveBackendTimer) {
-        console.log('[Cloud Saves] 清除现有的后端自动存档定时器。');
         clearInterval(autoSaveBackendTimer);
         autoSaveBackendTimer = null;
     }
 
     readConfig().then(config => {
         if (config.is_authorized && config.autoSaveEnabled && config.autoSaveTargetTag) {
-            const intervalMinutes = config.autoSaveInterval > 0 ? config.autoSaveInterval : 30;
-            const intervalMilliseconds = intervalMinutes * 60 * 1000;
-            if (intervalMilliseconds < 60000) {
-                 console.warn(`[Cloud Saves] 自动存档间隔 (${intervalMinutes}分钟) 过短，已调整为最少 1 分钟。`);
-                 intervalMilliseconds = 60000;
-            }
-            console.log(`[Cloud Saves] 启动后端定时存档，间隔 ${intervalMinutes} 分钟，目标: ${config.autoSaveTargetTag}`);
+            let intervalMilliseconds = (config.autoSaveInterval > 0 ? config.autoSaveInterval : 30) * 60 * 1000;
+            if (intervalMilliseconds < 60000) intervalMilliseconds = 60000;
             autoSaveBackendTimer = setInterval(performAutoSave, intervalMilliseconds);
-        } else {
-            console.log('[Cloud Saves] 后端定时存档未启动（未授权/未启用/无目标）。');
         }
     }).catch(err => {
         console.error('[Cloud Saves] 启动后端定时器前读取配置失败:', err);
@@ -1117,7 +998,6 @@ async function init(router) {
                     autoSaveTargetTag: config.autoSaveTargetTag || '',
                     has_github_token: !!config.github_token,
                 };
-                // console.log('[cloud-saves][DEBUG] Sending GET /config response:', JSON.stringify(safeConfig));
                 res.json(safeConfig);
             } catch (error) {
                 res.status(500).json({ success: false, message: '读取配置失败', error: error.message });
@@ -1131,37 +1011,23 @@ async function init(router) {
                     autoSaveEnabled, autoSaveInterval, autoSaveTargetTag
                 } = req.body;
                 let currentConfig = await readConfig();
-                // DEBUG: console.log('[cloud-saves][DEBUG] Received POST /config request body:', JSON.stringify(req.body, (key, value) => key === 'github_token' && value ? '******' : value)); // Mask token in log
 
                 currentConfig.repo_url = repo_url !== undefined ? repo_url.trim() : currentConfig.repo_url;
-                if (github_token) {
-                    // DEBUG: console.log('[cloud-saves][DEBUG] Saving new GitHub token (length:', github_token.length, ')');
-                    currentConfig.github_token = github_token;
-                } else {
-                    // DEBUG: console.log('[cloud-saves][DEBUG] No new GitHub token provided in POST /config request.');
-                }
+                if (github_token) currentConfig.github_token = github_token;
                 currentConfig.display_name = display_name !== undefined ? display_name.trim() : currentConfig.display_name;
                 currentConfig.branch = branch !== undefined ? (branch.trim() || DEFAULT_BRANCH) : currentConfig.branch;
-                if (is_authorized !== undefined) {
-                    currentConfig.is_authorized = !!is_authorized;
-                }
-                if (autoSaveEnabled !== undefined) {
-                    currentConfig.autoSaveEnabled = !!autoSaveEnabled;
-                }
+                if (is_authorized !== undefined) currentConfig.is_authorized = !!is_authorized;
+                if (autoSaveEnabled !== undefined) currentConfig.autoSaveEnabled = !!autoSaveEnabled;
+                
                 if (autoSaveInterval !== undefined) {
                     const interval = parseFloat(autoSaveInterval);
-                    if (isNaN(interval) || interval <= 0) {
-                        return res.status(400).json({ success: false, message: '无效的自动存档间隔。请输入一个大于 0 的数字。' });
-                    }
+                    if (isNaN(interval) || interval <= 0) return res.status(400).json({ success: false, message: '无效的自动存档间隔。' });
                     currentConfig.autoSaveInterval = interval;
                 }
-                if (autoSaveTargetTag !== undefined) {
-                    currentConfig.autoSaveTargetTag = autoSaveTargetTag.trim();
-                }
+                
+                if (autoSaveTargetTag !== undefined) currentConfig.autoSaveTargetTag = autoSaveTargetTag.trim();
 
                 await saveConfig(currentConfig);
-                // DEBUG: console.log('[cloud-saves][DEBUG] Config saved successfully after POST /config.');
-
                 setupBackendAutoSaveTimer();
 
                 const safeConfig = {
@@ -1174,10 +1040,8 @@ async function init(router) {
                     autoSaveInterval: currentConfig.autoSaveInterval,
                     autoSaveTargetTag: currentConfig.autoSaveTargetTag
                 };
-                // console.log('[cloud-saves][DEBUG] Sending POST /config response:', JSON.stringify(safeConfig));
                 res.json({ success: true, message: '配置保存成功', config: safeConfig });
             } catch (error) {
-                console.error('[cloud-saves] 保存配置失败:', error);
                 res.status(500).json({ success: false, message: '保存配置失败', error: error.message });
             }
         });
@@ -1190,12 +1054,10 @@ async function init(router) {
                 const targetBranch = branch || config.branch || DEFAULT_BRANCH;
 
                 if (!config.repo_url || !config.github_token) {
-                    return res.status(400).json({ success: false, message: '仓库URL和GitHub Token未配置，请先保存设置' });
+                    return res.status(400).json({ success: false, message: '仓库URL和GitHub Token未配置' });
                 }
 
-                if (branch && config.branch !== targetBranch) {
-                    config.branch = targetBranch;
-                }
+                if (branch && config.branch !== targetBranch) config.branch = targetBranch;
                 config.is_authorized = false;
 
                 const initResult = await initGitRepo();
@@ -1206,33 +1068,16 @@ async function init(router) {
                 authGit = simpleGit(DATA_DIR);
 
                 try {
-                     console.log('[cloud-saves] 准备初始提交...');
                      await authGit.add('.');
                      const status = await authGit.status();
                      if (!status.isClean()) {
-                         console.log('[cloud-saves] 执行初始提交...');
-                         // Add local config for user identity before committing
                          try {
-                             console.log('[cloud-saves] Configuring local Git identity for initial commit...');
                              await authGit.addConfig('user.name', 'Cloud Saves Plugin', false, 'local');
                              await authGit.addConfig('user.email', 'cloud-saves@plugin.local', false, 'local');
-                             console.log('[cloud-saves] Local Git identity configured.');
-                         } catch (configError) {
-                             console.error('[cloud-saves] Failed to configure local Git identity:', configError);
-                             // Decide if this should prevent the commit? For now, log and continue, commit might still fail.
-                         }
+                         } catch (configError) {}
                          await authGit.commit('Initial commit of existing data directory');
-                         console.log('[cloud-saves] 初始提交完成。');
-                     } else {
-                         console.log('[cloud-saves] data 目录无更改，跳过初始提交。');
                      }
-                 } catch (initialCommitError) {
-                      if (!initialCommitError.message.includes('nothing to commit')) {
-                           console.error('[cloud-saves] 执行初始提交时出错:', initialCommitError);
-                           return res.status(500).json({ success: false, message: `创建初始提交失败: ${initialCommitError.message}` });
-                      }
-                      console.log('[cloud-saves] 初始提交时无更改 (捕获异常)。');
-                 }
+                 } catch (initialCommitError) {}
 
                 let authUrl = config.repo_url;
                 if (config.repo_url.startsWith('https://') && !config.repo_url.includes('@')) {
@@ -1241,63 +1086,37 @@ async function init(router) {
                 const remotes = await authGit.getRemotes(true);
                 const origin = remotes.find(r => r.name === 'origin');
                 if (origin) {
-                     if (origin.refs.push !== authUrl) {
-                        await authGit.remote(['set-url', 'origin', authUrl]);
-                     }
-                } else {
-                     await authGit.addRemote('origin', authUrl);
-                }
-                console.log('[cloud-saves] 远程仓库已配置');
+                     if (origin.refs.push !== authUrl) await authGit.remote(['set-url', 'origin', authUrl]);
+                } else await authGit.addRemote('origin', authUrl);
 
                 try {
                     await authGit.fetch(['origin', '--tags', '--prune', '--force']);
-                    console.log("[cloud-saves] 获取标签成功。");
                 } catch(fetchError) {
                      await saveConfig(config);
                      return res.status(400).json({
                          success: false,
-                         message: '配置错误或权限不足：无法访问远程仓库或获取标签，请检查URL、Token权限。',
+                         message: '配置错误或权限不足：无法访问远程仓库或获取标签。',
                          details: fetchError.message
                      });
                 }
                 
-                console.log(`[cloud-saves] 检查远程分支 ${targetBranch}...`);
                 let remoteBranchExists = false;
                  try {
                      const remoteHeads = await authGit.listRemote(['--heads', 'origin', targetBranch]);
                      remoteBranchExists = typeof remoteHeads === 'string' && remoteHeads.includes(`refs/heads/${targetBranch}`);
-                 } catch (lsRemoteError) {
-                      console.warn(`[cloud-saves] ls-remote 检查分支 ${targetBranch} 失败，假设其不存在。错误:`, lsRemoteError.message);
-                      remoteBranchExists = false;
-                 }
-
+                 } catch (lsRemoteError) {}
 
                 if (!remoteBranchExists) {
-                    console.log(`[cloud-saves] 远程分支 ${targetBranch} 不存在，尝试创建...`);
                     try {
                         const localBranches = await authGit.branchLocal();
-                         if (!localBranches.all.includes(targetBranch)) {
-                             console.log(`[cloud-saves] 创建本地分支 ${targetBranch}...`);
-                             await authGit.checkout(['-b', targetBranch]); 
-                         } else {
-                              await authGit.checkout(targetBranch);
-                         }
+                         if (!localBranches.all.includes(targetBranch)) await authGit.checkout(['-b', targetBranch]); 
+                         else await authGit.checkout(targetBranch);
                          
-                        console.log(`[cloud-saves] 推送以创建远程分支 ${targetBranch}...`);
                         await authGit.push(['--set-upstream', 'origin', targetBranch]);
-                        console.log(`[cloud-saves] 远程分支 ${targetBranch} 创建成功`);
                     } catch (createBranchError) {
-                         console.error(`[cloud-saves] 自动创建/推送分支 ${targetBranch} 失败:`, createBranchError);
                          await saveConfig(config);
-                         if (createBranchError.message.includes('non-fast-forward')) {
-                              return res.status(500).json({ success: false, message: `远程分支 ${targetBranch} 已存在，但本地历史与之冲突 (non-fast-forward)。请尝试手动解决或选择其他分支名。`, details: createBranchError.message });
-                         }
-                         return res.status(500).json({ success: false, message: `无法自动创建或同步远程分支 ${targetBranch}。错误：${createBranchError.message}`, details: createBranchError.message });
+                         return res.status(500).json({ success: false, message: `無法建立同步分支 ${targetBranch}`, details: createBranchError.message });
                     }
-                } else {
-                    // Remote branch exists: Do nothing regarding local branch state.
-                    // The successful fetch/ls-remote earlier is sufficient validation.
-                    console.log(`[cloud-saves] 远程分支 ${targetBranch} 已存在。连接验证成功，不修改本地分支。`);
                 }
 
                 config.is_authorized = true;
@@ -1310,12 +1129,8 @@ async function init(router) {
                     if (validationResponse.ok) {
                         const userData = await validationResponse.json();
                         config.username = userData.login || null;
-                    } else {
-                        console.warn(`[cloud-saves] 获取GitHub用户名失败: ${validationResponse.status}`);
                     }
-                } catch (fetchUserError) {
-                    console.warn('[cloud-saves] 获取GitHub用户名时发生网络错误:', fetchUserError.message);
-                }
+                } catch (fetchUserError) {}
 
                 await saveConfig(config);
                 setupBackendAutoSaveTimer();
@@ -1334,13 +1149,11 @@ async function init(router) {
                 res.json({ success: true, message: '授权和配置成功', config: safeConfig });
 
             } catch (error) {
-                 console.error("[cloud-saves] 授权过程中发生严重错误:", error);
                  try {
                       let cfg = await readConfig();
                       cfg.is_authorized = false;
                       await saveConfig(cfg);
-                 } catch (saveErr) { /* Ignore */ }
-                 setupBackendAutoSaveTimer();
+                 } catch (saveErr) {}
                 res.status(500).json({ success: false, message: '授权过程中发生错误', error: error.message });
             }
         });
@@ -1356,9 +1169,7 @@ async function init(router) {
         });
 
         router.get('/saves', async (req, res) => {
-            if (currentOperation) {
-                return res.status(409).json({ success: false, message: `正在进行操作: ${currentOperation}` });
-            }
+            if (currentOperation) return res.status(409).json({ success: false, message: `正在进行操作: ${currentOperation}` });
             try {
                 const result = await listSaves();
                 res.json(result);
@@ -1368,385 +1179,144 @@ async function init(router) {
         });
 
         router.post('/saves', async (req, res) => {
-            if (currentOperation) {
-                return res.status(409).json({ success: false, message: `正在进行操作: ${currentOperation}` });
-            }
+            if (currentOperation) return res.status(409).json({ success: false, message: `正在进行操作: ${currentOperation}` });
             try {
                 const { name, description } = req.body;
-                if (!name) {
-                    return res.status(400).json({ success: false, message: '需要提供存档名称' });
-                }
+                if (!name) return res.status(400).json({ success: false, message: '需要提供存档名称' });
                 const result = await createSave(name, description);
                 res.json(result);
             } catch (error) {
-                 console.error('[cloud-saves] Unexpected error in POST /saves:', error);
                  res.status(500).json({ success: false, message: '创建存档时发生意外错误', details: error.message });
             }
         });
 
         router.post('/saves/load', async (req, res) => {
-            if (currentOperation) {
-                return res.status(409).json({ success: false, message: `正在进行操作: ${currentOperation}` });
-            }
+            if (currentOperation) return res.status(409).json({ success: false, message: `正在进行操作: ${currentOperation}` });
             try {
                 const { tagName } = req.body;
-                if (!tagName) {
-                    return res.status(400).json({ success: false, message: '需要提供存档标签名' });
-                }
+                if (!tagName) return res.status(400).json({ success: false, message: '需要提供存档标签名' });
                 const result = await loadSave(tagName);
                 res.json(result);
             } catch (error) {
-                console.error('[cloud-saves] Unexpected error in POST /saves/load:', error);
                 res.status(500).json({ success: false, message: '加载存档时发生意外错误', details: error.message });
             }
         });
 
         router.delete('/saves/:tagName', async (req, res) => {
-            if (currentOperation) {
-                return res.status(409).json({ success: false, message: `正在进行操作: ${currentOperation}` });
-            }
+            if (currentOperation) return res.status(409).json({ success: false, message: `正在进行操作: ${currentOperation}` });
             try {
                 const { tagName } = req.params;
-                if (!tagName) {
-                    return res.status(400).json({ success: false, message: '需要提供存档标签名' });
-                }
+                if (!tagName) return res.status(400).json({ success: false, message: '需要提供存档标签名' });
                 const result = await deleteSave(tagName);
                 res.json(result);
             } catch (error) {
-                console.error('[cloud-saves] Unexpected error in DELETE /saves/:tagName:', error);
                 res.status(500).json({ success: false, message: '删除存档时发生意外错误', details: error.message });
             }
         });
 
         router.put('/saves/:oldTagName', async (req, res) => {
-            if (currentOperation) {
-                return res.status(409).json({ success: false, message: `正在进行操作: ${currentOperation}` });
-            }
+            if (currentOperation) return res.status(409).json({ success: false, message: `正在进行操作: ${currentOperation}` });
             try {
                 const { oldTagName } = req.params;
                 const { newName, description } = req.body;
-                if (!oldTagName || !newName) {
-                    return res.status(400).json({ success: false, message: '需要提供旧存档标签名和新名称' });
-                }
+                if (!oldTagName || !newName) return res.status(400).json({ success: false, message: '需要提供旧存档标签名和新名称' });
                 const result = await renameSave(oldTagName, newName, description);
                 res.json(result);
             } catch (error) {
-                console.error('[cloud-saves] Unexpected error in PUT /saves/:oldTagName:', error);
                 res.status(500).json({ success: false, message: '重命名存档时发生意外错误', details: error.message });
             }
         });
 
         router.get('/saves/diff', async (req, res) => {
-            if (currentOperation) {
-                return res.status(409).json({ success: false, message: `正在进行操作: ${currentOperation}` });
-            }
+            if (currentOperation) return res.status(409).json({ success: false, message: `正在进行操作: ${currentOperation}` });
             try {
                 const { tag1, tag2 } = req.query;
-                if (!tag1 || !tag2) {
-                    return res.status(400).json({ success: false, message: '需要提供两个存档标签名/引用' });
-                }
+                if (!tag1 || !tag2) return res.status(400).json({ success: false, message: '需要提供两个存档标签名/引用' });
                 const result = await getSaveDiff(tag1, tag2);
                 res.json(result);
             } catch (error) {
-                console.error('[cloud-saves] Unexpected error in GET /saves/diff:', error);
                 res.status(500).json({ success: false, message: '获取存档差异时发生意外错误', details: error.message });
             }
         });
 
         router.post('/stash/apply', async (req, res) => {
-            if (currentOperation) {
-                return res.status(409).json({ success: false, message: `正在进行操作: ${currentOperation}` });
-            }
+            if (currentOperation) return res.status(409).json({ success: false, message: `正在进行操作: ${currentOperation}` });
             try {
                 const result = await applyTempStash();
                 res.json(result);
             } catch (error) {
-                 console.error('[cloud-saves] Unexpected error in POST /stash/apply:', error);
                 res.status(500).json({ success: false, message: '应用临时Stash时发生意外错误', details: error.message });
             }
         });
 
         router.post('/stash/discard', async (req, res) => {
-            if (currentOperation) {
-                return res.status(409).json({ success: false, message: `正在进行操作: ${currentOperation}` });
-            }
+            if (currentOperation) return res.status(409).json({ success: false, message: `正在进行操作: ${currentOperation}` });
             try {
                 const result = await discardTempStash();
                 res.json(result);
             } catch (error) {
-                 console.error('[cloud-saves] Unexpected error in POST /stash/discard:', error);
                 res.status(500).json({ success: false, message: '丢弃临时Stash时发生意外错误', details: error.message });
             }
         });
 
         router.post('/saves/:tagName/overwrite', async (req, res) => {
-            if (currentOperation) {
-                return res.status(409).json({ success: false, message: `正在进行操作: ${currentOperation}` });
-            }
+            if (currentOperation) return res.status(409).json({ success: false, message: `正在进行操作: ${currentOperation}` });
             currentOperation = 'overwrite_save';
             const { tagName } = req.params;
             let git;
             try {
                 const config = await readConfig();
-                if (!config.is_authorized) {
-                    return res.status(401).json({ success: false, message: '未授权，请先连接仓库' });
-                }
-                console.log(`[cloud-saves] 准备覆盖存档: ${tagName}`);
+                if (!config.is_authorized) return res.status(401).json({ success: false, message: '未授权，请先连接仓库' });
+                
                 git = await getGitInstance();
                 const branchToUse = config.branch || DEFAULT_BRANCH;
 
                 let originalDescription = `Overwrite of ${tagName}`;
                 try {
                      const tagInfoRaw = await git.raw('tag', '-n1', '-l', tagName, '--format=%(contents)');
-                     if (tagInfoRaw) {
-                         originalDescription = tagInfoRaw.trim().split('\n')[0];
-                     }
-                } catch (tagInfoError) { /* Ignore */ }
+                     if (tagInfoRaw) originalDescription = tagInfoRaw.trim().split('\n')[0];
+                } catch (tagInfoError) {}
 
-                await git.add('.');
-                const status = await git.status();
-                const hasChanges = !status.isClean();
+                await ensureGitignoreHidden();
+                const extensionsPath = path.join(DATA_DIR, 'default-user', 'extensions');
+                let maskedPaths = [];
                 let newCommitHash;
 
-                if (hasChanges) {
-                    const commitMessage = `Overwrite save: ${tagName}`;
-                    console.log(`[cloud-saves] 创建覆盖提交: "${commitMessage}"`);
-                    try {
-                        const commitResult = await git.commit(commitMessage);
-                        newCommitHash = commitResult.commit;
-                        console.log(`[cloud-saves] 新覆盖提交哈希: ${newCommitHash}`);
+                try {
+                    maskedPaths = await maskNestedGit(extensionsPath);
+                    await removeGitlinksFromIndex(git, 'default-user/extensions/');
+
+                    await git.add('.');
+                    const status = await git.status();
+                    const hasChanges = !status.isClean();
+
+                    if (hasChanges) {
                         try {
-                            await git.push('origin', branchToUse);
-                        } catch (pushCommitError) {
-                            console.warn(`[cloud-saves] 推送覆盖提交到分支 ${branchToUse} 失败:`, pushCommitError.message);
+                            const commitResult = await git.commit(`Overwrite save: ${tagName}`);
+                            newCommitHash = commitResult.commit;
+                            try { await git.push('origin', branchToUse); } catch (pushCommitError) {}
+                        } catch (commitError) {
+                             if (commitError.message.includes('nothing to commit')) {
+                                 newCommitHash = await git.revparse('HEAD');
+                             } else throw commitError;
                         }
-                    } catch (commitError) {
-                         if (commitError.message.includes('nothing to commit')) {
-                             console.log('[cloud-saves] 覆盖时无实际更改可提交，将使用当前 HEAD');
-                             newCommitHash = await git.revparse('HEAD');
-                         } else {
-                             throw commitError;
-                         }
+                    } else {
+                        newCommitHash = await git.revparse('HEAD');
                     }
-                } else {
-                    console.log('[cloud-saves] 覆盖时无实际更改可提交，将使用当前 HEAD');
-                    newCommitHash = await git.revparse('HEAD');
+                } finally {
+                    await unmaskNestedGit(maskedPaths);
                 }
 
                  if (!newCommitHash) throw new Error('无法确定用于覆盖的提交哈希');
 
-                try { await git.tag(['-d', tagName]); } catch(e) {/*ignore*/}
-                try {
-                    await git.push(['origin', `:refs/tags/${tagName}`]);
-                } catch (delRemoteErr) {
-                     if (!delRemoteErr.message.includes('remote ref does not exist')) {
-                          console.warn(`[cloud-saves] 删除远程旧标签 ${tagName} 时遇到问题:`, delRemoteErr.message);
-                     }
-                }
+                try { await git.tag(['-d', tagName]); } catch(e) {}
+                try { await git.push(['origin', `:refs/tags/${tagName}`]); } catch (delRemoteErr) {}
 
-                const tagMessage = originalDescription;
                 const nowTimestampOverwrite = new Date().toISOString();
-                const fullTagMessageOverwrite = `${tagMessage}\nLast Updated: ${nowTimestampOverwrite}`;
+                const fullTagMessageOverwrite = `${originalDescription}\nLast Updated: ${nowTimestampOverwrite}`;
                 await git.addAnnotatedTag(tagName, fullTagMessageOverwrite, newCommitHash);
 
                 try {
                     await git.push('origin', tagName);
                 } catch (pushTagError) {
-                     await git.tag(['-d', tagName]);
-                     throw pushTagError;
-                }
-
-                const saveNameMatch = tagName.match(/^save_\d+_(.+)$/);
-                let saveName = tagName;
-                if (saveNameMatch) { try { saveName = Buffer.from(saveNameMatch[1], 'base64url').toString('utf8'); } catch (e) {/*ignore*/} }
-                if (config.last_save && config.last_save.tag === tagName) {
-                    config.last_save = { name: saveName, tag: tagName, timestamp: nowTimestampOverwrite, description: originalDescription };
-                    await saveConfig(config);
-                }
-
-                res.json({ success: true, message: '存档覆盖成功' });
-
-            } catch (error) {
-                console.error(`[cloud-saves] 覆盖存档 ${tagName} 失败:`, error);
-                res.status(500).json(handleGitError(error, `覆盖存档 ${tagName}`));
-            } finally {
-                currentOperation = null;
-            }
-        });
-
-        router.post('/initialize', async (req, res) => {
-            if (currentOperation) {
-                return res.status(409).json({ success: false, message: `正在进行操作: ${currentOperation}` });
-            }
-            currentOperation = 'initialize_repo';
-            try {
-                console.log('[cloud-saves] 收到强制初始化仓库请求...');
-                const config = await readConfig();
-
-                const gitDirPath = path.join(DATA_DIR, '.git');
-                try {
-                    console.log(`[cloud-saves] 强制删除旧的 ${gitDirPath} 目录...`);
-                    await fs.rm(gitDirPath, { recursive: true, force: true });
-                    console.log(`[cloud-saves] 已强制删除旧的 ${gitDirPath} 目录`);
-                } catch (rmError) {
-                    console.error(`[cloud-saves] 删除旧的 ${gitDirPath} 目录失败 (可能不存在或权限问题):`, rmError);
-                }
-
-                const initResult = await initGitRepo();
-                if (!initResult.success) {
-                    return res.status(500).json({ success: false, message: `初始化Git仓库失败: ${initResult.message}`, details: initResult.details });
-                }
-                console.log('[cloud-saves] git init 成功 (强制)');
-
-                 const git = simpleGit(DATA_DIR);
-
-                try {
-                     console.log('[cloud-saves] 添加初始提交 (强制)...');
-                     await git.add('.');
-                     const status = await git.status();
-                     if (!status.isClean()) {
-                         await git.commit('Initial commit after forced re-initialization');
-                         console.log('[cloud-saves] 初始提交完成 (强制)');
-                     } else {
-                         console.log('[cloud-saves] data 目录无更改，跳过初始提交 (强制)');
-                     }
-                 } catch (initialCommitError) {
-                      if (!initialCommitError.message.includes('nothing to commit')) {
-                           console.error('[cloud-saves] 执行初始提交时出错 (强制):', initialCommitError);
-                      }
-                 }
-
-                if (config.repo_url) {
-                    console.log(`[cloud-saves] 配置远程仓库 (强制): ${config.repo_url}`);
-                    let authUrl = config.repo_url;
-                     if (config.github_token && authUrl.startsWith('https://') && !authUrl.includes('@')) {
-                         authUrl = config.repo_url.replace('https://', `https://x-access-token:${config.github_token}@`);
-                     }
-                     try {
-                          try { await git.removeRemote('origin'); } catch(e) {/*ignore*/}
-                          await git.addRemote('origin', authUrl);
-                          console.log('[cloud-saves] 配置远程仓库成功 (强制)');
-                     } catch (remoteError) {
-                          console.error('[cloud-saves] 配置远程仓库失败 (强制):', remoteError);
-                          return res.json({
-                              success: true,
-                              message: '仓库初始化成功，但配置远程仓库失败，请检查仓库 URL 或后续手动配置。',
-                              warning: true,
-                              details: remoteError.message
-                          });
-                     }
-                } else {
-                    console.log('[cloud-saves] 未配置仓库 URL，跳过配置远程仓库 (强制)');
-                }
-
-                res.json({ success: true, message: '仓库强制初始化成功' + (config.repo_url ? ' 并已配置远程仓库' : '') });
-
-            } catch (error) {
-                console.error('[cloud-saves] 强制初始化仓库时发生错误:', error);
-                res.status(500).json(handleGitError(error, '强制初始化仓库'));
-            } finally {
-                currentOperation = null;
-            }
-        });
-
-        router.post('/update/check-and-pull', async (req, res) => {
-            if (currentOperation) {
-                return res.status(409).json({ success: false, message: `正在进行操作: ${currentOperation}` });
-            }
-            currentOperation = 'check_update';
-            const pluginDir = __dirname;
-             const targetRemoteUrl = 'https://github.com/fuwei99/cloud-saves.git';
-             const targetBranch = 'main';
-             let git;
-
-            try {
-                console.log('[cloud-saves] 开始检查插件更新...');
-                 git = simpleGit(pluginDir); 
-
-                const isRepo = await git.checkIsRepo();
-                if (!isRepo) {
-                    console.warn('[cloud-saves] 插件目录不是有效的 Git 仓库。');
-                    return res.json({ success: true, status: 'not_git_repo', message: '无法自动更新：插件似乎不是通过 Git 安装的。' });
-                }
-
-                const remotes = await git.getRemotes(true);
-                const origin = remotes.find(r => r.name === 'origin');
-                if (!origin) {
-                     return res.json({ success: false, status: 'no_remote', message: '无法更新：插件仓库未配置名为 "origin" 的远程。' });
-                }
-                
-                const localRemoteUrl = origin.refs.push;
-                const targetRemoteWithoutGit = targetRemoteUrl.replace('.git', '');
-                if (localRemoteUrl !== targetRemoteUrl && localRemoteUrl !== targetRemoteWithoutGit) {
-                    console.warn(`[cloud-saves] 插件仓库的远程地址 (${localRemoteUrl}) 与目标 (${targetRemoteUrl}) 不匹配。`);
-                    return res.json({
-                        success: false,
-                        status: 'wrong_remote',
-                        message: `无法更新：插件远程地址 (${localRemoteUrl}) 与预期 (${targetRemoteUrl}) 不符。请确保插件是从官方地址克隆的。`
-                    });
-                }
-
-                 console.log('[cloud-saves] Fetching updates from origin...');
-                 await git.fetch('origin', targetBranch);
-
-                 const localHash = await git.revparse('HEAD');
-                 const remoteHash = await git.revparse(`origin/${targetBranch}`);
-
-                console.log(`[cloud-saves] 本地版本: ${localHash}`);
-                console.log(`[cloud-saves] 远程版本 (origin/${targetBranch}): ${remoteHash}`);
-
-                if (localHash === remoteHash) {
-                    console.log('[cloud-saves] 当前已是最新版本。');
-                    return res.json({ success: true, status: 'latest', message: '已是最新版本。' });
-                }
-
-                 const status = await git.status();
-                 if (!status.isClean()) {
-                     console.warn('[cloud-saves] 检测到本地修改，无法自动拉取更新。');
-                     return res.json({
-                         success: false,
-                         status: 'local_changes',
-                         message: '无法更新：检测到插件文件有本地修改。请先儲藏(stash)或提交您的更改，或手动执行 git pull。'
-                     });
-                 }
-
-                console.log('[cloud-saves] 检测到新版本，尝试执行 git pull...');
-                const pullSummary = await git.pull('origin', targetBranch); 
-
-                 if (pullSummary.files && pullSummary.files.length > 0 || pullSummary.summary.changes > 0) {
-                      console.log('[cloud-saves] git pull 成功！', pullSummary.summary);
-                      return res.json({ success: true, status: 'updated', message: '插件更新成功！请务必重启 SillyTavern 服务以应用更改。' });
-                 } else if (pullSummary.summary.alreadyUpdated) {
-                      console.log('[cloud-saves] Pull 表示已是最新 (可能 fetch 后状态已更新)');
-                       return res.json({ success: true, status: 'latest', message: '已是最新版本。' });
-                 }
-                 else {
-                      console.error('[cloud-saves] git pull 执行完成，但似乎未成功更新或状态未知。', pullSummary);
-                      return res.json({
-                           success: false,
-                           status: 'pull_failed',
-                           message: `更新似乎失败或状态未知。请检查控制台日志或尝试手动执行 git pull。`
-                      });
-                 }
-
-            } catch (error) {
-                console.error('[cloud-saves] 检查或执行插件更新时出错:', error);
-                res.status(500).json({ success: false, status:'error', message: `检查更新时发生内部错误: ${error.message}` });
-            } finally {
-                currentOperation = null;
-            }
-        });
-
-        setupBackendAutoSaveTimer();
-
-    } catch (error) {
-        console.error('[cloud-saves] 插件初始化失败:', error);
-    }
-}
-
-const plugin = {
-    info: info,
-    init: init,
-};
-
-module.exports = plugin;
+                     await git.tag

--- a/index.js
+++ b/index.js
@@ -529,6 +529,37 @@ async function listSaves() {
     }
 }
 
+// 新增：用於在 Git Checkout 讀取完畢後，地毯式搜索並還原那些從存檔中被拉取下來的擴展 .git 資訊
+async function restoreCheckoutGit(targetPath) {
+    try {
+        const entries = await fs.readdir(targetPath, { withFileTypes: true });
+        for (const entry of entries) {
+            const entryPath = path.join(targetPath, entry.name);
+            if (entry.isDirectory()) {
+                // 如果抓到了從雲端死灰復燃的隱藏 Git 檔案夾
+                if (entry.name === '.git_cloud_hidden') {
+                    const originalGit = path.join(targetPath, '.git');
+                    try {
+                        // 確保目標是乾淨的，先強制移除可能衝突的空 .git，接著把隱藏的資料夾改回 .git
+                        await fs.rm(originalGit, { recursive: true, force: true }).catch(() => {});
+                        await fs.rename(entryPath, originalGit);
+                    } catch (e) {
+                        console.error(`[cloud-saves] 無法還原隱藏的 git 目錄 ${entryPath}:`, e);
+                    }
+                } else if (entry.name !== '.git') {
+                    // 只要不是 .git，就繼續往下層資料夾尋找
+                    await restoreCheckoutGit(entryPath);
+                }
+            }
+        }
+    } catch (error) {
+        if (error.code !== 'ENOENT') {
+            console.error(`[cloud-saves] 掃描還原 .git_cloud_hidden 時發生錯誤 (${targetPath}):`, error);
+        }
+    }
+}
+
+// 完整版：修改自原有的 loadSave，加入了全新的掃描防護機制和完整的錯誤恢復
 async function loadSave(tagName) {
     try {
         currentOperation = 'load_save';
@@ -547,6 +578,7 @@ async function loadSave(tagName) {
         let stashCreated = false;
 
         try {
+            // 切換前，先保護現有的 .git
             maskedPaths = await maskNestedGit(extensionsPath);
 
             const status = await git.status();
@@ -555,18 +587,24 @@ async function loadSave(tagName) {
                 const stashResult = await git.stash(['push', '-u', '-m', 'Temporary stash before loading save']);
                 stashCreated = stashResult && !stashResult.includes('No local changes to save');
                 config.has_temp_stash = stashCreated;
-            } else config.has_temp_stash = false;
+            } else {
+                config.has_temp_stash = false;
+            }
             
             const commit = await git.revparse([tagName]);
             if (!commit) {
-                if(stashCreated) await git.stash(['pop']);
+                if (stashCreated) await git.stash(['pop']);
                 return { success: false, message: '获取存档提交哈希失败' };
             }
 
+            // 這一步會拉取舊的擴展與其 .git_cloud_hidden
             await git.checkout(commit);
 
         } finally {
+            // 1. 還原本來就存在的擴展
             await unmaskNestedGit(maskedPaths);
+            // 2. 地毯式補救措施：主動掃描並還原那些原本被刪除，但在 checkout 後才從存檔裡被復原的幽靈擴展
+            await restoreCheckoutGit(extensionsPath); 
         }
 
         config.current_save = {
@@ -580,7 +618,10 @@ async function loadSave(tagName) {
             message: '存档加载成功',
             stashCreated: stashCreated
         };
+
     } catch (error) {
+        console.error(`[cloud-saves] 載入存檔時發生錯誤:`, error.message);
+        // 如果發生錯誤，嘗試恢復 stash 以還原使用者的工作區
         try {
             const cfg = await readConfig();
             if (cfg.has_temp_stash) {
@@ -588,9 +629,15 @@ async function loadSave(tagName) {
                 await git.stash(['pop']);
                 cfg.has_temp_stash = false;
                 await saveConfig(cfg);
+                console.log('[cloud-saves] 已回退未保存的更改');
             }
-        } catch (popError) {}
-        return handleGitError(error, `加载存档 ${tagName}`);
+        } catch (recoverError) {
+            console.error('[cloud-saves] 錯誤恢復 (stash pop) 失敗:', recoverError.message);
+        }
+        
+        // 如果你的代碼中有 handleGitError 這個幫助函數，就用它；如果沒有，可以直接回傳 JSON
+        return { success: false, message: '加载存档失败', details: error.message };
+        
     } finally {
         currentOperation = null;
     }

--- a/index.js
+++ b/index.js
@@ -1,27 +1,112 @@
-const fs = require('fs').promises;
-const path = require('path');
-const express = require('express');
-const crypto = require('crypto');
-const simpleGit = require('simple-git');
-const GIT_BACKUP_NAME = '_git_cloud_backup'; // 終極破解：不使用點開頭！規避所有 .* 忽略規則
+/**
+ * ============================================================================
+ * SillyTavern Cloud Saves 插件 - 云端存档备份/恢复系统
+ * ============================================================================
+ * 
+ * 功能概述：
+ *   本插件通过 GitHub 仓库实现 SillyTavern 数据的云端备份和恢复。
+ *   核心机制是将 data/ 目录下的内容通过 Git 进行版本控制，
+ *   并使用 Git 标签(tag)来标记不同的存档点，从而支持：
+ *     - 创建存档（快照）
+ *     - 加载/恢复存档
+ *     - 删除存档
+ *     - 重命名存档
+ *     - 查看存档差异
+ *     - 定时自动存档（覆盖模式或创建新模式）
+ * 
+ * 关键技术难点与解决方案：
+ *   SillyTavern 的 data/default-user/extensions/ 目录下，
+ *   各个子插件目录内部包含 .git 文件夹（即嵌套 Git 仓库）。
+ *   这会导致 Git 将它们视为 submodule（Gitlink），
+ *   从而无法将插件内部文件作为普通文件进行版本追踪。
+ * 
+ *   解决方案（"终极破解"）：
+ *     在存档前，将所有嵌套的 .git 目录临时重命名为 _git_cloud_backup
+ *     （不以点开头，规避 .gitignore 的忽略规则），
+ *     存档完成后恢复为 .git。这样 Git 会把它们当作普通目录进行文件追踪。
+ * 
+ * 依赖项：
+ *   - simple-git: Node.js 的 Git 操作封装库
+ *   - node-fetch: 用于 GitHub API 调用（验证 token）
+ *   - express: Web 路由框架（由 SillyTavern 主程序注入）
+ *   - fs (promises): Node.js 文件系统操作
+ *   - path: 路径处理
+ *   - crypto: 加密模块（实际使用较少）
+ * 
+ * ============================================================================
+ */
 
+// =========================== 依赖导入 ===========================
+
+// fs.promises: 使用 Promise 风格的文件系统操作，避免回调地狱
+const fs = require('fs').promises;
+
+// path: 路径拼接、解析等操作
+const path = require('path');
+
+// express: SillyTavern 注入的路由模块，用于注册 API 端点
+const express = require('express');
+
+// crypto: 加密模块（目前保留以备将来使用，如哈希校验等）
+const crypto = require('crypto');
+
+// simple-git: 提供 Promise 风格的 Git 操作接口
+const simpleGit = require('simple-git');
+
+/**
+ * 终极破解常量：用于临时重命名嵌套的 .git 目录
+ * 
+ * 为什么不用点开头？
+ *   因为 .gitignore 通常会忽略所有点开头的文件/目录，
+ *   而我们需要这些改名后的目录能被 Git 追踪。
+ *   使用 _git_cloud_backup 这个没有点的名字，
+ *   就可以让内部的 Git 数据（objects, refs 等）作为普通文件被提交。
+ */
+const GIT_BACKUP_NAME = '_git_cloud_backup';
+
+// =========================== fetch 兼容层 ===========================
+
+/**
+ * fetch 变量：用于发送 HTTP 请求（调用 GitHub API 验证 token）
+ * 
+ * 兼容性处理逻辑：
+ *   1. 优先尝试使用 ESM 风格的 import('node-fetch')，适配新版本 Node.js
+ *   2. 如果失败，回退到 CommonJS 的 require('node-fetch')
+ *   3. 如果全部失败，使用 Node.js 原生 http/https 模块实现一个简易 fetch
+ *      （虽然功能简陋，但足以调用 GitHub API 的 /user 端点）
+ */
 let fetch;
 try {
+    // 尝试动态导入 node-fetch（适用于支持 ESM 的环境）
     import('node-fetch').then(module => {
         fetch = module.default;
     }).catch(() => {
+        // 如果动态导入失败，回退到 CommonJS require
         fetch = require('node-fetch');
     });
 } catch (error) {
+    // 记录导入失败的错误日志
     console.error('无法导入node-fetch:', error);
+
+    /**
+     * 简易 fetch 实现（仅支持基本 GET 请求）
+     * 使用 Node.js 原生 http/https 模块手动构造请求
+     * 
+     * @param {string} url - 请求的 URL
+     * @param {object} options - 请求选项（主要是 headers）
+     * @returns {Promise<object>} - 模拟 fetch 响应对象
+     */
     fetch = async (url, options) => {
         const https = require('https');
         const http = require('http');
         return new Promise((resolve, reject) => {
+            // 根据 URL 协议选择 http 或 https
             const client = url.startsWith('https') ? https : http;
             const req = client.request(url, options, (res) => {
                 let data = '';
+                // 接收响应数据块
                 res.on('data', (chunk) => { data += chunk; });
+                // 响应结束时组装完整的响应对象
                 res.on('end', () => {
                     resolve({
                         ok: res.statusCode >= 200 && res.statusCode < 300,
@@ -31,23 +116,57 @@ try {
                 });
             });
             req.on('error', reject);
+            // 如果有请求体(body)，写入请求流
             if (options && options.body) req.write(options.body);
             req.end();
         });
     };
 }
 
+// =========================== 插件元信息 ===========================
+
+/**
+ * info 对象：SillyTavern 插件注册所需的基本信息
+ * SillyTavern 会读取这个对象来识别和加载插件
+ */
 const info = {
-    id: 'cloud-saves',
-    name: 'Cloud Saves',
-    description: '通过GitHub仓库创建、管理和恢复SillyTavern的云端存档。',
-    version: '1.0.0',
+    id: 'cloud-saves',                                          // 插件唯一标识符
+    name: 'Cloud Saves',                                        // 插件显示名称
+    description: '通过GitHub仓库创建、管理和恢复SillyTavern的云端存档。',  // 插件描述
+    version: '1.0.0',                                           // 插件版本号
 };
 
+// =========================== 路径与默认配置 ===========================
+
+// 配置文件路径（与插件脚本在同一目录下）
 const CONFIG_PATH = path.join(__dirname, 'config.json');
+
+// SillyTavern 的数据目录路径（通过 process.cwd() 获取运行目录）
 const DATA_DIR = path.join(process.cwd(), 'data');
+
+// 默认分支名
 const DEFAULT_BRANCH = 'main';
 
+/**
+ * DEFAULT_CONFIG: 默认配置对象
+ * 包含了所有配置项的默认值，当配置文件不存在或格式错误时使用
+ * 
+ * 各字段说明：
+ *   repo_url:        GitHub 仓库的 HTTPS URL
+ *   branch:          操作的分支名
+ *   username:        通过 GitHub API 获取到的用户名（自动填充）
+ *   github_token:    GitHub 个人访问令牌（Personal Access Token）
+ *   display_name:    用户自定义的显示名称
+ *   is_authorized:   是否已通过授权验证
+ *   last_save:       最近一次创建的存档信息
+ *   current_save:    当前加载的存档信息
+ *   has_temp_stash:  是否存在临时 stash（加载存档前的自动备份）
+ *   autoSaveEnabled: 是否启用定时自动存档
+ *   autoSaveInterval: 定时存档间隔（分钟）
+ *   autoSaveTargetTag: 覆盖模式下要覆盖的目标存档标签名
+ *   autoSaveMode:    自动存档模式：'overwrite'（覆盖）或 'create'（创建新档）
+ *   autoSaveTimezoneOffset: 浏览器时区偏移量（分钟），用于创建模式的命名
+ */
 const DEFAULT_CONFIG = {
     repo_url: '',
     branch: DEFAULT_BRANCH,
@@ -65,13 +184,40 @@ const DEFAULT_CONFIG = {
     autoSaveTimezoneOffset: 0,
 };
 
+// =========================== 全局状态变量 ===========================
+
+/**
+ * currentOperation: 当前正在执行的操作名称
+ * 用于防止并发操作冲突。当有操作执行时，新的请求会被拒绝（返回 409）
+ * 可能的值：'create_save' | 'list_saves' | 'load_save' | 'delete_save' 
+ *          | 'rename_save' | 'get_save_diff' | 'auto_save' | 'overwrite_save' | null
+ */
 let currentOperation = null;
+
+/**
+ * autoSaveBackendTimer: 后端定时存档的计时器引用
+ * 使用 setInterval 实现，保存引用以便在配置更改时清除和重建
+ */
 let autoSaveBackendTimer = null;
 
+// =========================== 配置读写函数 ===========================
+
+/**
+ * readConfig - 读取并解析配置文件
+ * 
+ * 流程：
+ *   1. 读取 config.json 文件内容
+ *   2. 解析 JSON
+ *   3. 为缺失的字段填充默认值（兼容配置文件的版本升级）
+ *   4. 如果文件不存在或解析失败，创建默认配置文件并返回默认值
+ * 
+ * @returns {Promise<object>} - 当前的配置对象（已合并默认值）
+ */
 async function readConfig() {
     try {
         const data = await fs.readFile(CONFIG_PATH, 'utf8');
         const config = JSON.parse(data);
+        // 确保所有字段都有合理的默认值，防止旧配置文件升级后字段缺失
         config.branch = config.branch || DEFAULT_BRANCH;
         config.autoSaveEnabled = config.autoSaveEnabled === undefined ? DEFAULT_CONFIG.autoSaveEnabled : config.autoSaveEnabled;
         config.autoSaveInterval = config.autoSaveInterval === undefined ? DEFAULT_CONFIG.autoSaveInterval : config.autoSaveInterval;
@@ -80,36 +226,82 @@ async function readConfig() {
         config.autoSaveTimezoneOffset = config.autoSaveTimezoneOffset === undefined ? DEFAULT_CONFIG.autoSaveTimezoneOffset : config.autoSaveTimezoneOffset;
         return config;
     } catch (error) {
+        // 配置文件不存在或格式错误，创建默认配置
         console.warn('Failed to read or parse config, creating default:', error.message);
         await fs.writeFile(CONFIG_PATH, JSON.stringify(DEFAULT_CONFIG, null, 2));
         return { ...DEFAULT_CONFIG };
     }
 }
 
+/**
+ * saveConfig - 将配置对象写入配置文件
+ * 
+ * @param {object} config - 要保存的配置对象
+ * @returns {Promise<void>}
+ */
 async function saveConfig(config) {
     await fs.writeFile(CONFIG_PATH, JSON.stringify(config, null, 2));
 }
 
-// 確保 .gitignore 中包含隱藏的 .git 名稱，避免將巢狀 Git 操作紀錄推上 GitHub
+// =========================== .gitignore 维护 ===========================
+
+/**
+ * ensureGitignoreHidden - 确保 .gitignore 文件中包含必要的忽略规则
+ * 
+ * 目的：
+ *   防止 _git_cloud_hidden 目录（旧版屏蔽方案）被意外提交到 GitHub。
+ *   虽然新版使用 _git_cloud_backup，但需要兼容旧版本遗留的文件。
+ * 
+ * 注意：
+ *   _git_cloud_hidden 是旧版本的改名方案，新版本使用 _git_cloud_backup。
+ *   这个函数确保旧版本的遗留数据不会被提交。
+ */
 async function ensureGitignoreHidden() {
     const gitignorePath = path.join(DATA_DIR, '.gitignore');
     try {
         let content = '';
         try { content = await fs.readFile(gitignorePath, 'utf8'); } catch(e){}
+        // 检查是否已包含忽略规则
         if (!content.includes('.git_cloud_hidden')) {
+            // 确保内容末尾有换行符
             if (content && !content.endsWith('\n')) content += '\n';
+            // 追加忽略规则
             content += '.git_cloud_hidden\n';
             await fs.writeFile(gitignorePath, content, 'utf8');
-            console.log(`[cloud-saves] 自動在 .gitignore 加入了 .git_cloud_hidden`);
+            console.log(`[cloud-saves] 自动在 .gitignore 加入了 .git_cloud_hidden`);
         }
     } catch(e) {
-        console.error(`[cloud-saves] 更新 .gitignore 失敗:`, e);
+        console.error(`[cloud-saves] 更新 .gitignore 失败:`, e);
     }
 }
 
-// 1. 隱藏並強行綁架 .git，確保備份無死角
+// =========================== 嵌套 Git 目录处理（核心破解） ===========================
+
+/**
+ * maskNestedGit - 隐藏（绑架）所有嵌套的 .git 目录
+ * 
+ * 这是本插件的核心机制之一，用于解决嵌套 Git 仓库的追踪问题。
+ * 
+ * 工作原理：
+ *   1. 递归扫描目标目录下的所有子目录
+ *   2. 找到所有名为 .git 的子目录（即子插件的 Git 仓库）
+ *   3. 将它们重命名为 _git_cloud_backup（不带点前缀的名字）
+ *   4. 在重命名后的目录内：
+ *      a. 强制写入 !* 的 .gitignore，覆盖父级忽略规则，确保所有文件都被追踪
+ *      b. 创建 .gitkeep 文件在关键空目录中，确保 Git 保留目录结构
+ *   5. 跳过 node_modules 目录以提升扫描速度
+ *   6. 同时处理旧的 .git_cloud_hidden 目录（升级旧版本的数据）
+ * 
+ * @param {string} targetDir - 要扫描的起始目录
+ * @returns {Promise<Array<string>>} - 被重命名的原始 .git 路径列表（用于 unmaskNestedGit 恢复）
+ */
 async function maskNestedGit(targetDir) {
-    const maskedPaths = [];
+    const maskedPaths = [];  // 记录所有被处理的路径
+
+    /**
+     * scan - 递归扫描函数
+     * @param {string} currentDir - 当前正在扫描的目录
+     */
     async function scan(currentDir) {
         try {
             const entries = await fs.readdir(currentDir, { withFileTypes: true });
@@ -117,36 +309,50 @@ async function maskNestedGit(targetDir) {
                 const fullPath = path.join(currentDir, entry.name);
                 if (entry.isDirectory()) {
                     if (entry.name === '.git') {
+                        // === 发现嵌套的 .git 目录，开始处理 ===
                         const hiddenPath = path.join(currentDir, GIT_BACKUP_NAME);
                         try {
-                            // 將真正的 .git 改名，避開點開頭的忽略規則
+                            // 1. 删除可能存在的旧重命名目录（防止冲突）
                             await fs.rm(hiddenPath, { recursive: true, force: true }).catch(() => {});
+                            // 2. 将 .git 重命名为 _git_cloud_backup
                             await fs.rename(fullPath, hiddenPath);
                             
-                            // 暴力破解：強制在此目錄下植入最強的白名單規則，保證內部設定絕對被追蹤
+                            // 3. 暴力破解：强制植入白名单规则
+                            //    !* 表示覆盖所有父级忽略规则，无条件追踪此目录下的所有内容
                             await fs.writeFile(path.join(hiddenPath, '.gitignore'), "!*\n").catch(() => {});
                             
-                            // 補血機制：植入 .gitkeep，確保 Git 的基本造血空資料夾被跟隨打包
-                            const keepDirs = ['objects/info', 'objects/pack', 'refs/heads', 'refs/tags', 'branches', 'info'];
+                            // 4. 补血机制：在 Git 内部的关键空目录中植入 .gitkeep
+                            //    Git 不会追踪空目录，但这几个目录对 Git 的正常运行至关重要
+                            //    通过 .gitkeep 确保它们被保留
+                            const keepDirs = [
+                                'objects/info',   // Git 对象信息
+                                'objects/pack',   // Git 打包对象
+                                'refs/heads',     // 分支引用
+                                'refs/tags',      // 标签引用
+                                'branches',       // 分支信息
+                                'info'            // 仓库信息
+                            ];
                             for (const dir of keepDirs) {
                                 const keepPath = path.join(hiddenPath, dir);
                                 await fs.mkdir(keepPath, { recursive: true }).catch(() => {});
                                 await fs.writeFile(path.join(keepPath, '.gitkeep'), "").catch(() => {});
                             }
                             
+                            // 记录被处理的路径，以便之后恢复
                             maskedPaths.push(fullPath);
                         } catch (e) {
-                            console.error(`[cloud-saves] 無法隱藏 ${fullPath}:`, e);
+                            console.error(`[cloud-saves] 无法隐藏 ${fullPath}:`, e);
                         }
                     } else if (entry.name === '.git_cloud_hidden') {
-                        // 順手把以前遺留的舊存檔架構升級過來
+                        // === 处理旧版本的隐藏目录：升级到新格式 ===
                         const hiddenPath = path.join(currentDir, GIT_BACKUP_NAME);
                         try {
                             await fs.rename(fullPath, hiddenPath);
                             maskedPaths.push(path.join(currentDir, '.git'));
                         } catch (e) {}
                     } else if (entry.name !== GIT_BACKUP_NAME && entry.name !== 'node_modules') {
-                        // 跳過無用目錄加速掃描，遞迴掃描下一層
+                        // === 跳过无用目录，递归扫描下一层 ===
+                        // 跳过大备份目录本身（避免无限递归）和 node_modules（加速扫描）
                         await scan(fullPath);
                     }
                 }
@@ -157,64 +363,115 @@ async function maskNestedGit(targetDir) {
     return maskedPaths;
 }
 
-// 2. 解除綁架時，原封不動還原現存的插件
+/**
+ * unmaskNestedGit - 恢复（解绑）所有被隐藏的嵌套 .git 目录
+ * 
+ * 这是 maskNestedGit 的逆操作。
+ * 将 _git_cloud_backup 重命名回 .git，同时清理我们注入的强制追踪文件。
+ * 
+ * @param {Array<string>} maskedPaths - maskNestedGit 返回的原始路径列表
+ */
 async function unmaskNestedGit(maskedPaths) {
     for (const originalGit of maskedPaths) {
+        // 根据原始路径推导出重命名后的路径
         const hiddenPath = originalGit.replace(/\.git$/, GIT_BACKUP_NAME);
         try {
-            // 清理注入的強制追蹤規則
+            // 1. 清理我们注入的强制追踪规则文件
             await fs.rm(path.join(hiddenPath, '.gitignore'), { force: true }).catch(() => {});
+            // 2. 删除可能残留的原始 .git（防止重命名冲突）
             await fs.rm(originalGit, { recursive: true, force: true }).catch(() => {});
+            // 3. 恢复为 .git
             await fs.rename(hiddenPath, originalGit);
         } catch (e) {}
     }
 }
 
-// 從 index 緩存中清除可能早已留下的 Gitlink 舊參照（使得重新索引能以實際檔案型態備份）
+// =========================== Gitlink 清理 ===========================
+
+/**
+ * removeGitlinksFromIndex - 从 Git 索引中清除旧有的 Gitlink（子模块引用）
+ * 
+ * 问题背景：
+ *   如果之前嵌套的 .git 目录被 Git 当作子模块（Gitlink, mode=160000）记录在索引中，
+ *   那么即使现在它们被重命名为 _git_cloud_backup，Git 仍然会保留旧的 Gitlink 引用，
+ *   导致无法以普通文件形式追踪这些目录。
+ * 
+ * 解决方案：
+ *   扫描索引中所有 mode=160000 的文件记录，如果它们在目标前缀路径下，
+ *   使用 git rm --cached 将它们从索引中移除（但保留工作区文件）。
+ *   这样下一次 git add 就会将它们作为普通文件/目录重新索引。
+ * 
+ * @param {object} git - simple-git 实例
+ * @param {string} prefix - 要检查的路径前缀（如 'default-user/extensions/'）
+ */
 async function removeGitlinksFromIndex(git, prefix) {
-    console.log(`[cloud-saves] 正在檢查是否有舊 Gitlink 參照: ${prefix}`);
+    console.log(`[cloud-saves] 正在检查是否有旧 Gitlink 参照: ${prefix}`);
     const prefixPath = prefix.endsWith('/') ? prefix : prefix + '/';
 
     try {
+        // 使用 git ls-files --stage 获取索引中所有文件的详细信息
+        // 输出格式：<mode> <object> <stage>\t<file>
         const lsFilesOutput = await git.raw('ls-files', '--stage');
         if (!lsFilesOutput) return;
 
         const lines = lsFilesOutput.trim().split('\n');
         const gitlinksToRemove = [];
 
+        // 逐行解析，找出 mode=160000（Gitlink）且在目标前缀下的文件
         for (const line of lines) {
             const parts = line.split(/\s+/);
             if (parts.length >= 4) {
-                const mode = parts[0];
-                const filePath = parts.slice(3).join(' ');
+                const mode = parts[0];          // 文件模式
+                const filePath = parts.slice(3).join(' '); // 文件路径
+                // 160000 是 Gitlink（子模块）的特殊模式
                 if (mode === '160000' && filePath.startsWith(prefixPath)) {
                     gitlinksToRemove.push(filePath);
                 }
             }
         }
 
+        // 批量移除 Gitlink 引用（使用 --cached 保留工作区文件）
         if (gitlinksToRemove.length > 0) {
-            console.log(`[cloud-saves] 正在移除 ${gitlinksToRemove.length} 個擴展 Gitlink，改為完整追蹤實體檔案...`);
+            console.log(`[cloud-saves] 正在移除 ${gitlinksToRemove.length} 个扩展 Gitlink，改为完整追踪实体档案...`);
             for (const filePath of gitlinksToRemove) {
                 try {
-                     await git.raw('rm', '--cached', '--ignore-unmatch', filePath);
+                    // --cached: 只从索引中移除，保留工作区文件
+                    // --ignore-unmatch: 如果文件不在索引中也继续执行（容错处理）
+                    await git.raw('rm', '--cached', '--ignore-unmatch', filePath);
                 } catch (rmError) {}
             }
         }
     } catch (error) {
-        console.error(`[cloud-saves] 修正 Gitlink 時發生錯誤:`, error);
+        console.error(`[cloud-saves] 修正 Gitlink 时发生错误:`, error);
     }
 }
 
+// =========================== Git 实例创建 ===========================
+
+/**
+ * getGitInstance - 创建并配置 Git 操作实例
+ * 
+ * 每次调用都会返回一个新的 simple-git 实例，配置好：
+ *   1. 工作目录（通常是 DATA_DIR）
+ *   2. 认证信息（通过 GitHub Token 嵌入远程 URL）
+ *   3. 并发处理限制
+ * 
+ * 认证 URL 格式：
+ *   https://x-access-token:{token}@github.com/user/repo.git
+ * 
+ * @param {string} cwd - Git 工作目录，默认为 DATA_DIR
+ * @returns {Promise<object>} - 配置好的 simple-git 实例
+ */
 async function getGitInstance(cwd = DATA_DIR) {
     const options = {
-        baseDir: cwd,
-        binary: 'git',
-        maxConcurrentProcesses: 6,
+        baseDir: cwd,                    // Git 操作的基准目录
+        binary: 'git',                   // Git 可执行文件名
+        maxConcurrentProcesses: 6,       // 最大并发 Git 进程数
     };
     const git = simpleGit(options);
     const config = await readConfig();
 
+    // 如果是在 DATA_DIR 操作且已配置仓库和 token，自动设置认证的远程 URL
     if (cwd === DATA_DIR && config.repo_url && config.github_token) {
         try {
             const remotes = await git.getRemotes(true);
@@ -222,22 +479,33 @@ async function getGitInstance(cwd = DATA_DIR) {
             const originalUrl = config.repo_url;
             let authUrl = originalUrl;
 
+            // 构造带认证信息的 URL：在 https:// 后面插入 x-access-token
             if (originalUrl.startsWith('https://') && !originalUrl.includes('@')) {
                 authUrl = originalUrl.replace('https://', `https://x-access-token:${config.github_token}@`);
             }
+            // 如果远程 URL 不一致则更新
             if (origin && origin.refs.push !== authUrl) {
-                 await git.remote(['set-url', 'origin', authUrl]);
+                await git.remote(['set-url', 'origin', authUrl]);
             } else if (!origin && originalUrl) {
-                 await git.addRemote('origin', authUrl);
+                await git.addRemote('origin', authUrl);
             }
         } catch (error) {
-            console.warn(`[cloud-saves] 無法配置授權遠端 URL:`, error.message);
+            console.warn(`[cloud-saves] 无法配置授权远端 URL:`, error.message);
         }
     }
     
     return git;
 }
 
+/**
+ * handleGitError - 统一处理 Git 操作错误
+ * 
+ * 生成标准化的错误响应对象，包含成功标志、错误信息和详细堆栈。
+ * 
+ * @param {Error} error - 捕获的错误对象
+ * @param {string} operation - 正在执行的操作名称（用于错误消息）
+ * @returns {object} - 标准错误响应 { success: false, message, details, error }
+ */
 function handleGitError(error, operation = 'Git operation') {
     console.error(`[cloud-saves] ${operation} failed:`, error.message);
     return {
@@ -248,24 +516,45 @@ function handleGitError(error, operation = 'Git operation') {
     };
 }
 
+// =========================== Git 仓库初始化 ===========================
+
+/**
+ * isGitInitialized - 检查 data 目录是否已经完成 Git 初始化
+ * 
+ * 检查逻辑：
+ *   1. 检查 .git 目录是否存在
+ *   2. 使用 checkIsRepo() 进一步确认是否是有效的 Git 仓库
+ * 
+ * @returns {Promise<boolean>}
+ */
 async function isGitInitialized() {
     try {
         const git = simpleGit(DATA_DIR);
         const gitDir = path.join(DATA_DIR, '.git');
         try {
-           await fs.access(gitDir);
+            await fs.access(gitDir);  // 检查 .git 目录是否存在
         } catch {
-           return false;
+            return false;              // .git 目录不存在
         }
-        return await git.checkIsRepo();
+        return await git.checkIsRepo(); // 进一步验证仓库有效性
     } catch (error) {
         if (error.code !== 'ENOENT') {
-            console.error("[cloud-saves] 檢查 git 初始化發生錯誤:", error);
+            console.error("[cloud-saves] 检查 git 初始化发生错误:", error);
         }
         return false;
     }
 }
 
+/**
+ * addGitkeepRecursively - 递归地在所有空目录中添加 .gitkeep 文件
+ * 
+ * 背景：
+ *   Git 不会追踪空目录。但在我们的使用场景中，
+ *   空的子目录也是有意义的（如默认角色目录结构），
+ *   为了让 Git 能追踪这些目录结构，需要在空目录中放置 .gitkeep 文件。
+ * 
+ * @param {string} directory - 要处理的起始目录
+ */
 async function addGitkeepRecursively(directory) {
     try {
         const entries = await fs.readdir(directory, { withFileTypes: true });
@@ -274,15 +563,17 @@ async function addGitkeepRecursively(directory) {
 
         for (const entry of entries) {
             if (entry.isFile() && entry.name === '.gitkeep') {
-                hasGitkeep = true;
+                hasGitkeep = true;  // 当前目录已有 .gitkeep
             }
             if (entry.isDirectory()) {
+                // 跳过 .git 目录（避免干扰仓库本身）
                 if (entry.name !== '.git') {
                     subDirectories.push(path.join(directory, entry.name));
                 }
             }
         }
 
+        // 如果当前目录为空（没有文件且有子目录的已经在上面加入了递归列表），添加 .gitkeep
         if (!hasGitkeep) {
             const gitkeepPath = path.join(directory, '.gitkeep');
             try {
@@ -294,49 +585,85 @@ async function addGitkeepRecursively(directory) {
             }
         }
 
+        // 递归处理子目录
         for (const subDir of subDirectories) {
             await addGitkeepRecursively(subDir);
         }
     } catch (error) {}
 }
 
+/**
+ * initGitRepo - 在 data 目录中初始化 Git 仓库
+ * 
+ * 流程：
+ *   1. 检查是否已初始化，如果是则跳过
+ *   2. 执行 git init
+ *   3. 递归添加 .gitkeep 文件到所有空目录
+ *   4. 创建 .gitignore 文件：
+ *      - !* 覆盖父级忽略规则，确保 data 目录内容被追踪
+ *      - 明确忽略一些不需要备份的子目录（如缓存、临时文件）
+ * 
+ * @returns {Promise<object>} - 操作结果
+ */
 async function initGitRepo() {
+    // 如果已经初始化，直接返回成功
     if (await isGitInitialized()) {
         console.log('[cloud-saves] Git repository already initialized in data directory.');
         await ensureGitignoreHidden();
-        return { success: true, message: 'Git倉庫已在data目錄中初始化' };
+        return { success: true, message: 'Git仓库已在data目录中初始化' };
     }
 
-    console.log('[cloud-saves] 正在data目錄中初始化Git倉庫:', DATA_DIR);
+    console.log('[cloud-saves] 正在data目录中初始化Git仓库:', DATA_DIR);
     try {
         const git = simpleGit(DATA_DIR);
-        await git.init();
+        await git.init();  // 执行 git init
         console.log('[cloud-saves] git init 成功');
 
+        // 在所有空目录中放入 .gitkeep，确保目录结构被追踪
         console.log('[cloud-saves] Adding .gitkeep files to ensure all directory tracking...');
         await addGitkeepRecursively(DATA_DIR);
 
+        // 创建主 .gitignore 文件
         try {
             const gitignorePath = path.join(DATA_DIR, '.gitignore');
-            const gitignoreContent = "# Ensure data directory contents are tracked, overriding parent ignores.\n!*\n\n# Ignore specific subdirectories within data\n_uploads/\n_cache/\n_storage/\n_webpack/\n.git_cloud_hidden\n";
+            const gitignoreContent = 
+                "# 确保 data 目录内容被追踪，覆盖父级忽略规则\n!*\n\n" +
+                "# 忽略不需要备份的子目录\n" +
+                "_uploads/\n" +      // 上传文件（可能很大）
+                "_cache/\n" +        // 缓存目录
+                "_storage/\n" +      // 存储目录
+                "_webpack/\n" +      // Webpack 打包输出
+                ".git_cloud_hidden\n"; // 旧版本隐藏目录
             await fs.writeFile(gitignorePath, gitignoreContent, 'utf8');
-            console.log(`[cloud-saves] 已成功創建主 ${gitignorePath}`);
+            console.log(`[cloud-saves] 已成功创建主 ${gitignorePath}`);
         } catch (gitignoreError) {
-            console.error(`[cloud-saves] 創建主 .gitignore 文件失敗:`, gitignoreError);
+            console.error(`[cloud-saves] 创建立 .gitignore 文件失败:`, gitignoreError);
         }
 
-        return { success: true, message: 'Git倉庫初始化成功，並添加了.gitkeep文件' };
+        return { success: true, message: 'Git仓库初始化成功，并添加了.gitkeep文件' };
     } catch (error) {
         return handleGitError(error, '初始化Git仓库');
     }
 }
 
+// =========================== 远程仓库配置 ===========================
+
+/**
+ * configureRemote - 配置远程仓库的 URL
+ * 
+ * 如果远程 origin 已存在，更新其 URL；如果不存在，添加新的远程仓库。
+ * 自动将 GitHub Token 嵌入 URL 以实现认证。
+ * 
+ * @param {string} repoUrl - GitHub 仓库的 HTTPS URL
+ * @returns {Promise<object>} - 操作结果
+ */
 async function configureRemote(repoUrl) {
     try {
         const git = await getGitInstance();
         const remotes = await git.getRemotes(true);
         const origin = remotes.find(r => r.name === 'origin');
         
+        // 构造带认证信息的 URL
         let authUrl = repoUrl;
         const config = await readConfig();
         if (repoUrl.startsWith('https://') && config.github_token && !repoUrl.includes('@')) {
@@ -344,10 +671,12 @@ async function configureRemote(repoUrl) {
         }
 
         if (origin) {
+            // 远程已存在，更新 URL（仅在 URL 不同时更新）
             if (origin.refs.push !== authUrl) {
                 await git.remote(['set-url', 'origin', authUrl]);
             }
         } else {
+            // 远程不存在，添加新的
             await git.addRemote('origin', authUrl);
         }
         return { success: true, message: '远程仓库配置成功' };
@@ -356,65 +685,108 @@ async function configureRemote(repoUrl) {
     }
 }
 
+// =========================== 存档创建 ===========================
+
+/**
+ * createSave - 创建一个新的云端存档
+ * 
+ * 这是本插件的核心功能之一。完整流程如下：
+ * 
+ * 1. 【预处理】确保 .gitignore 包含隐藏规则
+ * 2. 【屏蔽嵌套 Git】调用 maskNestedGit 将所有子插件的 .git 目录重命名
+ * 3. 【清理 Gitlink】移除索引中旧的子模块引用
+ * 4. 【暂存变更】git add .
+ * 5. 【提交】如果有变更则 git commit
+ * 6. 【恢复嵌套 Git】调用 unmaskNestedGit 恢复 .git 目录
+ * 7. 【创建标签】使用 git tag -a 创建带注释的标签
+ * 8. 【推送】推送标签和分支到远程仓库
+ * 9. 【更新配置】记录最后保存的存档信息
+ * 
+ * 标签命名格式：
+ *   save_{timestamp}_{base64url(name)}
+ *   其中 timestamp 是 Date.now() 的值
+ *   base64url 编码确保文件名安全（不包含 / 等特殊字符）
+ * 
+ * @param {string} name - 存档名称
+ * @param {string} description - 存档描述（可选）
+ * @returns {Promise<object>} - 操作结果，包含 saveData
+ */
 async function createSave(name, description) {
     try {
+        // 设置当前操作标志，防止并发操作
         currentOperation = 'create_save';
-        console.log(`[cloud-saves] 正在創建新存檔: ${name}, 描述: ${description}`);
+        console.log(`[cloud-saves] 正在创建新存盘: ${name}, 描述: ${description}`);
+        
         await ensureGitignoreHidden();
         const config = await readConfig();
         const git = await getGitInstance();
         const branchToPush = config.branch || DEFAULT_BRANCH;
 
+        // 生成标签名：使用 base64url 编码名称以确保安全
         const encodedName = Buffer.from(name).toString('base64url');
         const tagName = `save_${Date.now()}_${encodedName}`;
         const nowTimestamp = new Date().toISOString();
+
+        // 标签消息包含描述和最后更新时间
         const tagMessage = description || `存档: ${name}`;
         const fullTagMessage = `${tagMessage}\nLast Updated: ${nowTimestamp}`;
 
+        // 确定 extensions 目录路径
         const extensionsPath = path.join(DATA_DIR, 'default-user', 'extensions');
         let maskedPaths = [];
         let commitNeeded = false;
 
         try {
+            // ======== 核心步骤：屏蔽嵌套 Git 目录 ========
             maskedPaths = await maskNestedGit(extensionsPath);
+            // 清理旧的 Gitlink 引用，确保文件能被正常追踪
             await removeGitlinksFromIndex(git, 'default-user/extensions/');
 
+            // 暂存所有变更
             await git.add('.');
             const status = await git.status();
             commitNeeded = !status.isClean();
 
+            // 如果有变更，提交
             if (commitNeeded) {
-                console.log('[cloud-saves] 已掃描完成，執行提交...');
+                console.log('[cloud-saves] 已扫描完成，执行提交...');
                 try {
                     await git.commit(`存档: ${name}`);
                 } catch (commitError) {
+                    // "nothing to commit" 错误是正常的（如果所有文件都已在之前的提交中）
                     if (commitError.message.includes('nothing to commit')) {
-                         commitNeeded = false;
+                        commitNeeded = false;
                     } else {
                         throw commitError;
                     }
                 }
             }
         } finally {
+            // ======== 无论如何都要恢复嵌套 Git 目录 ========
             await unmaskNestedGit(maskedPaths);
         }
 
-        console.log('[cloud-saves] 創建標籤並推送...');
+        // 创建带注释的 Git 标签
+        console.log('[cloud-saves] 创建标签并推送...');
         await git.addAnnotatedTag(tagName, fullTagMessage);
 
+        // 获取当前分支
         const currentBranchStatus = await git.branch();
         const currentBranch = currentBranchStatus.current;
 
+        // 如果有新的提交且在正确的分支上，推送分支
         if (commitNeeded && currentBranch === branchToPush && !currentBranchStatus.detached) {
             try {
-                 await git.push('origin', currentBranch);
+                await git.push('origin', currentBranch);
             } catch (pushError) {
-                console.warn(`[cloud-saves] 推送分支錯誤:`, pushError.message);
+                console.warn(`[cloud-saves] 推送分支错误:`, pushError.message);
             }
         }
 
+        // 推送标签到远程仓库
         await git.push(['origin', tagName]);
 
+        // 更新配置中的 last_save 信息
         config.last_save = {
             name: name,
             tag: tagName,
@@ -436,31 +808,52 @@ async function createSave(name, description) {
     } catch (error) {
         return handleGitError(error, `创建存档 ${name}`);
     } finally {
+        // 无论如何清除当前操作标志
         currentOperation = null;
     }
 }
 
+// =========================== 存档列表获取 ===========================
+
+/**
+ * listSaves - 获取远程仓库中所有存档的列表
+ * 
+ * 流程：
+ *   1. 使用 ls-remote 获取远程仓库中的所有 save_ 标签（高效，无需完整 fetch）
+ *   2. 对比本地标签，删除本地存在但远程不存在的"幽灵"标签
+ *   3. 拉取远程标签数据（获取注释、作者、日期等信息）
+ *   4. 格式化返回存档列表
+ * 
+ * 为什么先 ls-remote 再 fetch？
+ *   ls-remote 速度快，不需要下载标签数据，
+ *   可以先用它确认哪些标签真实存在，清理完本地残留后再 fetch 详细信息。
+ * 
+ * @returns {Promise<object>} - { success, saves: Array }
+ */
 async function listSaves() {
     try {
         currentOperation = 'list_saves';
         console.log('[cloud-saves] 获取存档列表');
         const git = await getGitInstance();
 
-        // 1. 使用 ls-remote 獲取當前遠端倉庫的「真實標籤清單」
+        // ======== 步骤1: 使用 ls-remote 获取远程真实标签清单 ========
         console.log('[cloud-saves] Fetching remote tags list via ls-remote...');
         let lsRemoteOutput = '';
         try {
             lsRemoteOutput = await git.listRemote(['--tags', 'origin']);
         } catch (remoteErr) {
-            console.warn('[cloud-saves] 無法訪問遠端倉庫，可能是尚未初始化完成。', remoteErr.message);
+            // 无法访问远程仓库（例如空仓库、网络问题等）
+            console.warn('[cloud-saves] 无法访问远端仓库，可能是尚未初始化完成。', remoteErr.message);
         }
         
+        // 从 ls-remote 输出中提取 save_ 开头的标签名
         const remoteTags = new Set();
         if (lsRemoteOutput) {
             const lines = lsRemoteOutput.trim().split('\n');
             for (const line of lines) {
                 if (!line) continue;
-                // 過濾出 save_ 開頭的標籤，並忽略 Git 特有的 ^{} 指標後綴
+                // 匹配格式: <hash>\trefs/tags/<tagName>
+                // 忽略 ^{} 后缀（这是 Git 对带注释标签的特殊引用）
                 const match = line.match(/refs\/tags\/(save_[^\s\^]+)/);
                 if (match) {
                     remoteTags.add(match[1]);
@@ -468,53 +861,58 @@ async function listSaves() {
             }
         }
 
-        // 2. 清理本地殘留：找出本地所有的 save_ 標籤，把「不在當前遠端倉庫」的直接刪除
+        // ======== 步骤2: 清理本地残留的"幽灵"标签 ========
+        // 本地有但远程没有的标签，说明该存档已被从远程删除，应从本地清理
         const localTagsSummary = await git.tags(['-l', 'save_*']);
         const localTags = localTagsSummary.all || [];
         let prunedCount = 0;
         for (const localTag of localTags) {
             if (!remoteTags.has(localTag)) {
                 try {
-                    await git.tag(['-d', localTag]);
+                    await git.tag(['-d', localTag]);  // 删除本地标签
                     prunedCount++;
                 } catch(e) {}
             }
         }
         if (prunedCount > 0) {
-            console.log(`[cloud-saves] 已清理 ${prunedCount} 個不屬於當前遠端倉庫的本地殘留存檔(標籤)。`);
+            console.log(`[cloud-saves] 已清理 ${prunedCount} 个不属于当前远端仓库的本地残留存档(标签)。`);
         }
 
-        // 3. 從遠端拉取最新的標籤資料到本地 (以獲取註解內容和日期)
+        // ======== 步骤3: 拉取远程标签详细信息 ========
         console.log('[cloud-saves] Fetching tags data from remote...');
         try {
             await git.fetch(['origin', '--tags', '--force']);
         } catch (fetchErr) {
-            console.warn('[cloud-saves] 拉取標籤時出現警告，如果是空倉庫則為正常現象。');
+            console.warn('[cloud-saves] 拉取标签时出现警告，如果是空仓库则为正常现象。');
         }
 
+        // 使用 git tag 的格式化输出一次性获取所有标签的详细信息
+        // %00 是 null 字符分隔符，便于解析多行字段
         const formatString = "%(refname:short)%00%(creatordate:iso)%00%(taggername)%00%(subject)%00%(contents)";
         const tagOutput = await git.raw('tag', '-l', 'save_*', '--sort=-creatordate', `--format=${formatString}`);
 
         if (!tagOutput) return { success: true, saves: [] };
 
+        // 解析标签信息
         const saves = tagOutput.trim().split('\n').filter(Boolean).map(line => {
             const parts = line.split('\0');
             if (parts.length < 5) return null;
 
             const tagName = parts[0];
             
-            // 【二次保險過濾】確保返回的標籤確實在遠端的清單中
+            // 二次保险过滤：确保返回的标签确实存在于远程
             if (!remoteTags.has(tagName)) return null;
 
             const createdAt = new Date(parts[1]).toISOString();
             const taggerName = parts[2] || '未知';
-            const subject = parts[3];
-            const body = parts[4] || '';
+            const subject = parts[3];      // 标签简短描述
+            const body = parts[4] || '';   // 标签完整消息体
 
             let name = tagName;
             let description = subject;
             let updatedAt = createdAt;
 
+            // 从标签消息体中提取 "Last Updated" 时间戳
             const bodyLines = body.split('\n');
             const lastUpdatedLine = bodyLines.find(l => l.startsWith('Last Updated:'));
             if (lastUpdatedLine) {
@@ -527,12 +925,15 @@ async function listSaves() {
                 description = subject;
             }
             
+            // 从标签名中解码存档名称
+            // 标签格式：save_{timestamp}_{base64url(name)}
             const tagNameMatch = tagName.match(/^save_\d+_(.+)$/);
             if (tagNameMatch) {
                 try {
                     const encodedName = tagNameMatch[1];
                     name = Buffer.from(encodedName, 'base64url').toString('utf8');
                 } catch (decodeError) {
+                    // 解码失败时使用原始编码文本
                     name = tagNameMatch[1];
                 }
             }
@@ -556,31 +957,52 @@ async function listSaves() {
     }
 }
 
-// 3. 還原被刪除後、又被 Git Checkout 下來的「復活插件」
+// =========================== 存档加载后的恢复处理 ===========================
+
+/**
+ * restoreCheckoutGit - 恢复被 Git checkout 还原出来的嵌套 Git 目录
+ * 
+ * 背景：
+ *   当执行 git checkout 切换存档时，之前通过 maskNestedGit 改名并提交到仓库的
+ *   _git_cloud_backup 目录会被还原到工作区。但这个目录在正常使用中应该叫 .git。
+ * 
+ * 此函数递归扫描目录，找到 _git_cloud_backup 或 .git_cloud_hidden 目录，
+ * 将它们重命名回 .git，并清理注入的 .gitignore 和 .gitkeep 文件。
+ * 同时确保必要的 Git 内部目录结构存在。
+ * 
+ * @param {string} targetPath - 要扫描并恢复的目录
+ */
 async function restoreCheckoutGit(targetPath) {
     try {
         const entries = await fs.readdir(targetPath, { withFileTypes: true });
         for (const entry of entries) {
             const entryPath = path.join(targetPath, entry.name);
             if (entry.isDirectory()) {
-                // 如果抓到了我們的新版備份檔(或是舊版)，就把它改回真正的 .git
+                // 发现被改名的 Git 目录（新版或旧版命名）
                 if (entry.name === GIT_BACKUP_NAME || entry.name === '.git_cloud_hidden') {
                     const originalGit = path.join(targetPath, '.git');
                     try {
+                        // 1. 删除可能存在的旧 .git 目录
                         await fs.rm(originalGit, { recursive: true, force: true }).catch(() => {});
+                        // 2. 重命名回 .git
                         await fs.rename(entryPath, originalGit);
                         
-                        // 清理掉我們強制追蹤的髒東西
+                        // 3. 清理我们注入的强制追踪文件
                         await fs.rm(path.join(originalGit, '.gitignore'), { force: true }).catch(() => {});
                         await fs.rm(path.join(originalGit, '.gitkeep'), { force: true }).catch(() => {});
                         
-                        // 保險：強制建立基本空資料夾架構
-                        const requiredGitDirs = ['objects/info', 'objects/pack', 'refs/heads', 'refs/tags', 'branches', 'info'];
+                        // 4. 确保 Git 内部必要目录结构存在（防止 checkout 后目录缺失）
+                        const requiredGitDirs = [
+                            'objects/info', 'objects/pack', 
+                            'refs/heads', 'refs/tags', 
+                            'branches', 'info'
+                        ];
                         for (const dirName of requiredGitDirs) {
                             await fs.mkdir(path.join(originalGit, dirName), { recursive: true }).catch(() => {});
                         }
                     } catch (e) {}
                 } else if (entry.name !== '.git' && entry.name !== 'node_modules') {
+                    // 递归处理子目录（跳过已处理的 .git 和 node_modules）
                     await restoreCheckoutGit(entryPath);
                 }
             }
@@ -588,15 +1010,41 @@ async function restoreCheckoutGit(targetPath) {
     } catch (error) {}
 }
 
-// 4. 完整的 Load Save 處理流程
+// =========================== 存档加载 ===========================
+
+/**
+ * loadSave - 加载指定的存档到当前工作区
+ * 
+ * 这是本插件的另一个核心功能。完整流程：
+ * 
+ * 1. 【拉取标签】fetch 远程标签确保本地是最新的
+ * 2. 【验证标签】检查指定的标签是否存在
+ * 3. 【屏蔽嵌套 Git】调用 maskNestedGit 保护当前扩展的 .git 目录
+ * 4. 【创建临时保存】如果当前有未保存的更改，先 stash 暂存并标记
+ * 5. 【获取提交】通过标签获取对应的提交哈希
+ * 6. 【切换版本】执行 git checkout 切换到目标提交
+ * 7. 【恢复嵌套 Git】两步恢复：
+ *    a. unmaskNestedGit: 恢复被屏蔽的当前扩展 .git
+ *    b. restoreCheckoutGit: 恢复被 checkout 还原出来的存档中的 .git
+ * 8. 【更新配置】记录当前加载的存档信息
+ * 
+ * 错误恢复：
+ *   如果在加载过程中出错，会尝试 pop 之前创建的 stash，
+ *   避免用户的未保存更改丢失。
+ * 
+ * @param {string} tagName - 要加载的存档标签名（如 save_1234567890_xxx）
+ * @returns {Promise<object>} - { success, message, stashCreated }
+ */
 async function loadSave(tagName) {
     try {
         currentOperation = 'load_save';
-        console.log(`[cloud-saves] 正在載入存檔: ${tagName}`);
+        console.log(`[cloud-saves] 正在载入存档: ${tagName}`);
         const git = await getGitInstance();
         const config = await readConfig();
 
+        // 拉取所有远程标签（确保本地数据最新）
         await git.fetch(['origin', '--tags']);
+        // 验证标签是否存在
         const tags = await git.tags(['-l', tagName]);
         if (!tags || !tags.all.includes(tagName)) {
             return { success: false, message: '找不到指定的存档标签' };
@@ -607,9 +1055,10 @@ async function loadSave(tagName) {
         let stashCreated = false;
 
         try {
-            // 切換分支前，保護現有的 .git
+            // ======== 步骤1: 保护当前扩展的 .git 目录 ========
             maskedPaths = await maskNestedGit(extensionsPath);
 
+            // ======== 步骤2: 如果有未保存更改，创建临时 stash ========
             const status = await git.status();
             if (!status.isClean()) {
                 console.log('[cloud-saves] 检测到未保存的更改，在回档前创建临时保存点');
@@ -620,21 +1069,27 @@ async function loadSave(tagName) {
                 config.has_temp_stash = false;
             }
             
+            // ======== 步骤3: 获取标签对应的提交哈希 ========
             const commit = await git.revparse([tagName]);
             if (!commit) {
+                // 如果获取失败但已创建 stash，先恢复 stash
                 if (stashCreated) await git.stash(['pop']);
                 return { success: false, message: '获取存档提交哈希失败' };
             }
 
-            // 這一步會向本地覆寫檔案，把舊存檔的 _git_cloud_backup 給放出來
+            // ======== 步骤4: 切换工作区到指定提交 ========
+            // 这一步会还原存档时提交的 _git_cloud_backup 目录到工作区
             await git.checkout(commit);
 
         } finally {
-            // 這兩步將無死角還原所有受影響以及「死灰復燃」的插件 .git
+            // ======== 步骤5: 双重恢复嵌套 Git 目录 ========
+            // a. 恢复当前扩展的 .git（被 maskNestedGit 屏蔽的）
             await unmaskNestedGit(maskedPaths);
+            // b. 恢复存档中还原出来的 .git（被 checkout 放出来的 _git_cloud_backup）
             await restoreCheckoutGit(extensionsPath); 
         }
 
+        // ======== 步骤6: 记录当前加载的存档 ========
         config.current_save = {
             tag: tagName,
             loaded_at: new Date().toISOString()
@@ -648,7 +1103,8 @@ async function loadSave(tagName) {
         };
 
     } catch (error) {
-        console.error(`[cloud-saves] 載入存檔時發生錯誤:`, error.message);
+        console.error(`[cloud-saves] 载入存档时发生错误:`, error.message);
+        // ======== 错误恢复：尝试还原 stash ========
         try {
             const cfg = await readConfig();
             if (cfg.has_temp_stash) {
@@ -658,7 +1114,7 @@ async function loadSave(tagName) {
                 await saveConfig(cfg);
             }
         } catch (recoverError) {
-            console.error('[cloud-saves] 錯誤恢復失敗:', recoverError.message);
+            console.error('[cloud-saves] 错误恢复失败:', recoverError.message);
         }
         
         return { success: false, message: '加载存档失败', details: error.message };
@@ -668,32 +1124,55 @@ async function loadSave(tagName) {
     }
 }
 
+// =========================== 存档删除 ===========================
+
+/**
+ * deleteSave - 删除指定的存档（本地和远程标签）
+ * 
+ * 流程：
+ *   1. 删除本地标签
+ *   2. 推送删除到远程（push :refs/tags/{tagName}）
+ *   3. 如果当前加载的存档就是被删除的，清除 current_save
+ * 
+ * 容错处理：
+ *   如果远程删除失败（如网络问题），仍然返回成功但附带警告信息
+ * 
+ * @param {string} tagName - 要删除的存档标签名
+ * @returns {Promise<object>}
+ */
 async function deleteSave(tagName) {
     try {
         currentOperation = 'delete_save';
         console.log(`[cloud-saves] 正在删除存档: ${tagName}`);
         const git = await getGitInstance();
 
+        // 删除本地标签
         await git.tag(['-d', tagName]);
         
+        // 删除远程标签
         try {
+            // 格式：git push origin :refs/tags/{tagName}
             await git.push(['origin', `:refs/tags/${tagName}`]);
         } catch (pushError) {
-            if (!pushError.message.includes('remote ref does not exist') && !pushError.message.includes('deletion of') ) {
-                 const config = await readConfig();
-                 if (config.current_save && config.current_save.tag === tagName) {
-                     config.current_save = null;
-                     await saveConfig(config);
-                 }
-                 return {
-                     success: true,
-                     message: '本地存档已删除，但删除远程存档失败，可能是网络问题或权限问题',
-                     warning: true,
-                     details: pushError.message
-                 };
+            // 远程标签不存在或删除失败的非严重错误
+            if (!pushError.message.includes('remote ref does not exist') && 
+                !pushError.message.includes('deletion of')) {
+                // 仍然清理本地配置中的引用
+                const config = await readConfig();
+                if (config.current_save && config.current_save.tag === tagName) {
+                    config.current_save = null;
+                    await saveConfig(config);
+                }
+                return {
+                    success: true,
+                    message: '本地存档已删除，但删除远程存档失败，可能是网络问题或权限问题',
+                    warning: true,
+                    details: pushError.message
+                };
             }
         }
 
+        // 如果当前加载的就是被删除的存档，清除引用
         const config = await readConfig();
         if (config.current_save && config.current_save.tag === tagName) {
             config.current_save = null;
@@ -708,6 +1187,23 @@ async function deleteSave(tagName) {
     }
 }
 
+// =========================== 存档重命名 ===========================
+
+/**
+ * renameSave - 重命名存档（实质是创建新标签并删除旧标签）
+ * 
+ * 两种情况：
+ *   1. 名称相同：只更新标签的注释信息和时间戳（原地更新）
+ *   2. 名称不同：创建新标签 → 推送新标签 → 删除旧标签
+ * 
+ * 标签名包含 base64url 编码后的存档名称，
+ * 所以重命名实际上需要生成新的标签名。
+ * 
+ * @param {string} oldTagName - 旧的存档标签名
+ * @param {string} newName - 新的存档名称
+ * @param {string} description - 新的存档描述
+ * @returns {Promise<object>}
+ */
 async function renameSave(oldTagName, newName, description) {
     try {
         currentOperation = 'rename_save';
@@ -715,17 +1211,20 @@ async function renameSave(oldTagName, newName, description) {
         const git = await getGitInstance();
         const config = await readConfig();
 
+        // 验证旧标签存在
         const tags = await git.tags(['-l', oldTagName]);
-         if (!tags || !tags.all.includes(oldTagName)) {
-             return { success: false, message: '找不到指定的存档标签' };
-         }
+        if (!tags || !tags.all.includes(oldTagName)) {
+            return { success: false, message: '找不到指定的存档标签' };
+        }
+        // 获取旧标签对应的提交哈希
         const commit = await git.revparse([oldTagName]);
         if (!commit) return { success: false, message: '获取存档提交失败' };
 
+        // 解码旧标签中的存档名称
         let oldDecodedName = oldTagName;
         const oldNameMatch = oldTagName.match(/^save_\d+_(.+)$/);
         if (oldNameMatch) {
-            try { oldDecodedName = Buffer.from(oldNameMatch[1], 'base64url').toString('utf8'); } catch (e) { /* ignore */ }
+            try { oldDecodedName = Buffer.from(oldNameMatch[1], 'base64url').toString('utf8'); } catch (e) {}
         }
 
         const nowTimestamp = new Date().toISOString();
@@ -733,32 +1232,52 @@ async function renameSave(oldTagName, newName, description) {
         const fullNewMessage = `${newDescription}\nLast Updated: ${nowTimestamp}`;
 
         if (oldDecodedName === newName) {
+            // === 名称相同：原地更新标签信息 ===
             await git.tag(['-a', '-f', oldTagName, '-m', fullNewMessage, commit]);
-            await git.push(['origin', oldTagName, '--force']);
-             return { success: true, message: '存档描述和更新时间已更新', oldTag: oldTagName, newTag: oldTagName, newName: newName };
+            await git.push(['origin', oldTagName, '--force']);  // 强制推送更新
+            return { 
+                success: true, 
+                message: '存档描述和更新时间已更新', 
+                oldTag: oldTagName, 
+                newTag: oldTagName, 
+                newName: newName 
+            };
         } else {
-             const encodedNewName = Buffer.from(newName).toString('base64url');
-             const newTagName = `save_${Date.now()}_${encodedNewName}`;
+            // === 名称不同：创建新标签并删除旧标签 ===
+            const encodedNewName = Buffer.from(newName).toString('base64url');
+            const newTagName = `save_${Date.now()}_${encodedNewName}`;
 
-             await git.addAnnotatedTag(newTagName, fullNewMessage, commit);
-             try {
+            // 1. 创建新标签（指向相同的提交）
+            await git.addAnnotatedTag(newTagName, fullNewMessage, commit);
+            
+            // 2. 推送新标签
+            try {
                 await git.push('origin', newTagName);
-             } catch (pushError) {
-                  await git.tag(['-d', newTagName]);
-                  throw pushError;
-             }
+            } catch (pushError) {
+                // 推送失败时回滚本地新标签
+                await git.tag(['-d', newTagName]);
+                throw pushError;
+            }
 
-             await git.tag(['-d', oldTagName]);
-             try {
-                 await git.push(['origin', `:refs/tags/${oldTagName}`]);
-             } catch (e) {}
+            // 3. 删除旧标签
+            await git.tag(['-d', oldTagName]);
+            try {
+                await git.push(['origin', `:refs/tags/${oldTagName}`]);
+            } catch (e) {}
 
+            // 4. 更新 current_save 引用
             if (config.current_save && config.current_save.tag === oldTagName) {
                 config.current_save.tag = newTagName;
                 await saveConfig(config);
             }
 
-            return { success: true, message: '存档重命名成功', oldTag: oldTagName, newTag: newTagName, newName: newName };
+            return { 
+                success: true, 
+                message: '存档重命名成功', 
+                oldTag: oldTagName, 
+                newTag: newTagName, 
+                newName: newName 
+            };
         }
     } catch (error) {
         return handleGitError(error, `重命名存档 ${oldTagName} -> ${newName}`);
@@ -767,46 +1286,69 @@ async function renameSave(oldTagName, newName, description) {
     }
 }
 
+// =========================== 存档差异对比 ===========================
+
+/**
+ * getSaveDiff - 获取两个存档（或引用）之间的文件差异
+ * 
+ * 使用 git diff --name-status 获取变更的文件列表和变更类型。
+ * 
+ * 特殊处理：
+ *   如果 ref1 是空树哈希（4b825dc...），表示与"空状态"对比，
+ *   使用 git ls-tree 获取 ref2 的所有文件（相当于"新建"所有文件）。
+ * 
+ * 空树哈希是 Git 中一个特殊的 SHA-1 值，代表一个没有任何内容的提交。
+ * 
+ * @param {string} ref1 - 第一个引用（标签名、分支名或提交哈希）
+ * @param {string} ref2 - 第二个引用
+ * @returns {Promise<object>} - { success, changedFiles: [{status, fileName}] }
+ */
 async function getSaveDiff(ref1, ref2) {
     try {
         currentOperation = 'get_save_diff';
         const git = simpleGit(DATA_DIR);
-        const emptyTreeHash = '4b825dc642cb6eb9a060e54bf8d69288fbee4904';
+        const emptyTreeHash = '4b825dc642cb6eb9a060e54bf8d69288fbee4904';  // Git 空树哈希
 
+        // 验证 ref1 是否存在（特殊处理空树哈希）
         try {
             await git.revparse(['--verify', ref1]);
         } catch (error) {
             if ((ref1.endsWith('^') || ref1.endsWith('~1')) && error.message.includes('unknown revision')) {
                 ref1 = emptyTreeHash;
             } else if (ref1 === emptyTreeHash) {
-                
+                // 确认是空树哈希
             } else {
-                 return { success: false, message: `找不到或无效的引用: ${ref1}`, details: error.message };
+                return { success: false, message: `找不到或无效的引用: ${ref1}`, details: error.message };
             }
         }
+        // 验证 ref2 是否存在
         try {
             await git.revparse(['--verify', ref2]);
         } catch (error) {
-             return { success: false, message: `找不到或无效的引用: ${ref2}`, details: error.message };
+            return { success: false, message: `找不到或无效的引用: ${ref2}`, details: error.message };
         }
 
         let diffOutput;
-         try {
-             if (ref1 === emptyTreeHash) {
-                 const lsTreeOutput = await git.raw('ls-tree', '-r', '--name-only', ref2);
-                 if (!lsTreeOutput) return { success: true, changedFiles: [] };
-                 changedFiles = lsTreeOutput.trim().split('\n').filter(Boolean).map(fileName => ({
-                     status: 'A',
-                     fileName: fileName
-                 }));
-                 return { success: true, changedFiles: changedFiles };
-             } else {
-                 diffOutput = await git.diff(['--name-status', ref1, ref2]);
-             }
-         } catch (diffError) {
-              return handleGitError(diffError, `获取差异 ${ref1} <-> ${ref2}`);
-         }
+        try {
+            if (ref1 === emptyTreeHash) {
+                // 与空树对比：列出 ref2 的所有文件（都是新增的）
+                const lsTreeOutput = await git.raw('ls-tree', '-r', '--name-only', ref2);
+                if (!lsTreeOutput) return { success: true, changedFiles: [] };
+                const changedFiles = lsTreeOutput.trim().split('\n').filter(Boolean).map(fileName => ({
+                    status: 'A',      // A = Added（新增）
+                    fileName: fileName
+                }));
+                return { success: true, changedFiles: changedFiles };
+            } else {
+                // 普通对比：使用 git diff --name-status
+                diffOutput = await git.diff(['--name-status', ref1, ref2]);
+            }
+        } catch (diffError) {
+            return handleGitError(diffError, `获取差异 ${ref1} <-> ${ref2}`);
+        }
 
+        // 解析 diff 输出：每行格式为 "<status>\t<filename>"
+        // status 可能的值：A（新增）、M（修改）、D（删除）、R（重命名）、C（复制）
         const changedFiles = diffOutput.trim().split('\n')
             .filter(Boolean)
             .map(line => {
@@ -826,6 +1368,25 @@ async function getSaveDiff(ref1, ref2) {
     }
 }
 
+// =========================== Git 状态查询 ===========================
+
+/**
+ * getGitStatus - 获取当前 data 目录的 Git 工作区状态
+ * 
+ * 返回的信息包括：
+ *   - initialized: 是否已初始化 Git 仓库
+ *   - changes: 变更文件列表（状态+路径）
+ *   - currentBranch: 当前分支（detached 状态下为 null）
+ *   - currentSave: 当前加载的存档信息
+ *   - isDetached: 是否处于 detached HEAD 状态
+ *   - ahead/behind: 与远程仓库的提交领先/落后数量
+ * 
+ * 特殊处理：
+ *   在没有活跃操作时，会先屏蔽嵌套 Git 目录再获取状态，
+ *   这样可以显示那些包含了嵌套 Git 目录的插件的变更情况。
+ * 
+ * @returns {Promise<object>} - 格式化的状态对象
+ */
 async function getGitStatus() {
     try {
         const git = simpleGit(DATA_DIR);
@@ -834,6 +1395,7 @@ async function getGitStatus() {
         let status = null;
         if (isInitialized) {
             if (!currentOperation) {
+                // 没有活跃操作时：先屏蔽嵌套 Git 目录，获取真实状态，再恢复
                 const extensionsPath = path.join(DATA_DIR, 'default-user', 'extensions');
                 let maskedPaths = await maskNestedGit(extensionsPath);
                 try {
@@ -842,31 +1404,34 @@ async function getGitStatus() {
                     await unmaskNestedGit(maskedPaths);
                 }
             } else {
+                // 有活跃操作时：直接获取状态（不干扰正在进行的操作）
                 status = await git.status();
             }
         }
 
+        // 获取分支信息
         let currentBranch = null;
         let isDetached = false;
         if (isInitialized) {
-             try {
-                 const branchSummary = await git.branch();
-                 currentBranch = branchSummary.current;
-                 isDetached = branchSummary.detached;
-             } catch (branchError) {}
+            try {
+                const branchSummary = await git.branch();
+                currentBranch = branchSummary.current;
+                isDetached = branchSummary.detached;  // git checkout 到特定提交时会出现
+            } catch (branchError) {}
         }
 
         const config = await readConfig();
         const currentSave = config.current_save;
 
+        // 格式化状态信息
         const formattedStatus = {
-             initialized: isInitialized,
-             changes: status ? status.files.map(f => `${f.working_dir}${f.index} ${f.path}`) : [],
-             currentBranch: isDetached ? null : currentBranch,
-             currentSave: currentSave,
-             isDetached: isDetached,
-             ahead: status ? status.ahead : 0,
-             behind: status ? status.behind : 0,
+            initialized: isInitialized,
+            changes: status ? status.files.map(f => `${f.working_dir}${f.index} ${f.path}`) : [],
+            currentBranch: isDetached ? null : currentBranch,
+            currentSave: currentSave,
+            isDetached: isDetached,
+            ahead: status ? status.ahead : 0,
+            behind: status ? status.behind : 0,
         };
         
         return formattedStatus;
@@ -875,6 +1440,14 @@ async function getGitStatus() {
     }
 }
 
+/**
+ * hasUnsavedChanges - 检查是否有未保存的更改
+ * 
+ * 与 getGitStatus 类似的处理逻辑：
+ * 先屏蔽嵌套 Git 目录再检查状态，获取真实的工作区状态。
+ * 
+ * @returns {Promise<boolean>}
+ */
 async function hasUnsavedChanges() {
     try {
         const git = simpleGit(DATA_DIR);
@@ -882,6 +1455,7 @@ async function hasUnsavedChanges() {
 
         let isClean = true;
         if (!currentOperation) {
+            // 没有活跃操作：先屏蔽再检查
             const extensionsPath = path.join(DATA_DIR, 'default-user', 'extensions');
             let maskedPaths = await maskNestedGit(extensionsPath);
             try {
@@ -896,10 +1470,20 @@ async function hasUnsavedChanges() {
         }
         return !isClean;
     } catch (error) {
-         return false;
+        return false;
     }
 }
 
+// =========================== 临时 Stash 管理 ===========================
+
+/**
+ * checkTempStash - 检查是否存在加载存档前自动创建的临时 stash
+ * 
+ * 加载存档时如果用户有未保存的更改，插件会自动创建 stash 来保护这些更改。
+ * 此函数检查这个 stash 是否还存在（用户可能已经处理了）。
+ * 
+ * @returns {Promise<object>} - { exists: boolean }
+ */
 async function checkTempStash() {
     const config = await readConfig();
     if (!config.has_temp_stash) return { exists: false };
@@ -908,17 +1492,19 @@ async function checkTempStash() {
         const git = simpleGit(DATA_DIR);
         const stashList = await git.stashList();
 
+        // stash 列表为空
         if (stashList.total === 0) {
             config.has_temp_stash = false;
             await saveConfig(config);
             return { exists: false };
         }
+        // 查找带有特定消息的 stash
         const tempStash = stashList.all.find(s => s.message.includes('Temporary stash before loading save'));
-         if (!tempStash) {
+        if (!tempStash) {
             config.has_temp_stash = false;
             await saveConfig(config);
             return { exists: false };
-         }
+        }
 
         return { exists: true };
     } catch (error) {
@@ -926,6 +1512,14 @@ async function checkTempStash() {
     }
 }
 
+/**
+ * applyTempStash - 应用（恢复）临时 stash
+ * 
+ * 将加载存档时自动保存的临时更改恢复到工作区。
+ * 应用成功后删除该 stash。
+ * 
+ * @returns {Promise<object>}
+ */
 async function applyTempStash() {
     const config = await readConfig();
     if (!config.has_temp_stash) {
@@ -937,7 +1531,10 @@ async function applyTempStash() {
         const stashList = await git.stashList();
 
         const stashMessageToFind = 'Temporary stash before loading save';
-        const stashIndex = stashList.all.findIndex(s => s.message && s.message.includes(stashMessageToFind));
+        // 找到对应的 stash 索引
+        const stashIndex = stashList.all.findIndex(
+            s => s.message && s.message.includes(stashMessageToFind)
+        );
 
         if (stashIndex === -1) {
             config.has_temp_stash = false;
@@ -946,8 +1543,9 @@ async function applyTempStash() {
         }
 
         const stashRef = `stash@{${stashIndex}}`;
-        await git.stash(['apply', stashRef]);
+        await git.stash(['apply', stashRef]);  // 应用 stash
 
+        // 应用后删除 stash
         try {
             await git.stash(['drop', stashRef]);
         } catch (dropError) {}
@@ -961,6 +1559,13 @@ async function applyTempStash() {
     }
 }
 
+/**
+ * discardTempStash - 丢弃临时 stash（不应用更改）
+ * 
+ * 直接删除加载存档时创建的临时 stash，放弃那些未保存的更改。
+ * 
+ * @returns {Promise<object>}
+ */
 async function discardTempStash() {
     const config = await readConfig();
     if (!config.has_temp_stash) {
@@ -972,7 +1577,9 @@ async function discardTempStash() {
         const stashList = await git.stashList();
 
         const stashMessageToFind = 'Temporary stash before loading save';
-        const stashIndex = stashList.all.findIndex(s => s.message && s.message.includes(stashMessageToFind));
+        const stashIndex = stashList.all.findIndex(
+            s => s.message && s.message.includes(stashMessageToFind)
+        );
 
         if (stashIndex === -1) {
             config.has_temp_stash = false;
@@ -981,7 +1588,7 @@ async function discardTempStash() {
         }
 
         const stashRef = `stash@{${stashIndex}}`;
-        await git.stash(['drop', stashRef]);
+        await git.stash(['drop', stashRef]);  // 直接删除 stash
 
         config.has_temp_stash = false;
         await saveConfig(config);
@@ -992,7 +1599,32 @@ async function discardTempStash() {
     }
 }
 
+// =========================== 定时自动存档 ===========================
+
+/**
+ * performAutoSave - 执行一次自动存档操作
+ * 
+ * 支持两种模式：
+ * 
+ *   1. 覆盖模式 (overwrite)：
+ *      将当前工作区提交并强制更新指定的存档标签。
+ *      适用于"保持一个定期更新的备份"场景。
+ *      流程：屏蔽嵌套Git → 暂存 → 提交 → 推送 → 删除旧标签 → 创建新标签 → 推送标签
+ * 
+ *   2. 创建模式 (create)：
+ *      像正常手动存档一样创建新标签。
+ *      命名格式：YYYY-MM-DD - HHMM (Auto Save)
+ *      使用浏览器时区偏移量来调整时间。
+ * 
+ * 安全保护：
+ *   - 如果当前有其他操作在执行，跳过本次自动存档
+ *   - 如果未授权或未启用自动存档，直接退出
+ *   - 覆盖模式必须配置目标标签名
+ * 
+ * @returns {Promise<void>}
+ */
 async function performAutoSave() {
+    // 如果有其他操作在执行，跳过本次自动存档
     if (currentOperation) return;
     currentOperation = 'auto_save';
     
@@ -1000,6 +1632,7 @@ async function performAutoSave() {
     let git;
     try {
         config = await readConfig();
+        // 未授权或未启用则跳过
         if (!config.is_authorized || !config.autoSaveEnabled) {
             currentOperation = null;
             return;
@@ -1007,10 +1640,10 @@ async function performAutoSave() {
 
         const mode = config.autoSaveMode || 'overwrite';
 
+        // ======== 创建模式 ========
         if (mode === 'create') {
-            // 創建新存檔模式：像手動備份一樣創建新存檔
             const offsetMinutes = config.autoSaveTimezoneOffset || 0;
-            // 根據瀏覽器時區偏移調整服務器UTC時間
+            // 根据浏览器时区偏移调整服务器 UTC 时间
             const adjustedTime = new Date(Date.now() + offsetMinutes * 60 * 1000);
             const year = adjustedTime.getUTCFullYear();
             const month = String(adjustedTime.getUTCMonth() + 1).padStart(2, '0');
@@ -1019,39 +1652,40 @@ async function performAutoSave() {
             const minutes = String(adjustedTime.getUTCMinutes()).padStart(2, '0');
             const saveName = `${year}-${month}-${day} - ${hours}${minutes} (Auto Save)`;
             
-            console.log(`[Cloud Saves Auto] 創建模式: 自動創建新存檔 "${saveName}"`);
+            console.log(`[Cloud Saves Auto] 创建模式: 自动创建新存档 "${saveName}"`);
             
-            // 臨時清除 currentOperation 以便調用 createSave
+            // 临时清除 currentOperation 以便调用 createSave
             currentOperation = null;
             try {
                 const result = await createSave(saveName, 'Auto Save');
                 if (result.success) {
-                    console.log(`[Cloud Saves Auto] 成功創建自動存檔: ${result.saveData?.tag}`);
+                    console.log(`[Cloud Saves Auto] 成功创建自动存档: ${result.saveData?.tag}`);
                 } else {
-                    console.error(`[Cloud Saves Auto] 創建自動存檔失敗: ${result.message}`);
+                    console.error(`[Cloud Saves Auto] 创建自动存档失败: ${result.message}`);
                 }
             } catch (createError) {
-                console.error(`[Cloud Saves Auto] 創建自動存檔異常:`, createError);
+                console.error(`[Cloud Saves Auto] 创建自动存档异常:`, createError);
             }
             return;
         }
 
-        // 以下是覆蓋模式 (overwrite) 的原有邏輯
+        // ======== 覆盖模式 ========
         if (!config.autoSaveTargetTag) {
-            console.log('[Cloud Saves Auto] 覆蓋模式需要目標標籤，但未設置');
+            console.log('[Cloud Saves Auto] 覆盖模式需要目标标签，但未设置');
             currentOperation = null;
             return;
         }
 
         const targetTag = config.autoSaveTargetTag;
-        console.log(`[Cloud Saves Auto] 開始自動覆蓋存檔到: ${targetTag}`);
+        console.log(`[Cloud Saves Auto] 开始自动覆盖存档到: ${targetTag}`);
         git = await getGitInstance();
         const branchToUse = config.branch || DEFAULT_BRANCH;
 
+        // 尝试读取原有标签描述
         let originalDescription = `Auto Save Overwrite: ${targetTag}`;
         try {
-             const tagInfoRaw = await git.raw('tag', '-n1', '-l', targetTag, '--format=%(contents)');
-             if (tagInfoRaw) originalDescription = tagInfoRaw.trim().split('\n')[0];
+            const tagInfoRaw = await git.raw('tag', '-n1', '-l', targetTag, '--format=%(contents)');
+            if (tagInfoRaw) originalDescription = tagInfoRaw.trim().split('\n')[0];
         } catch (tagInfoError) {}
 
         await ensureGitignoreHidden();
@@ -1060,9 +1694,11 @@ async function performAutoSave() {
         let newCommitHash;
 
         try {
+            // 屏蔽嵌套 Git 目录
             maskedPaths = await maskNestedGit(extensionsPath);
             await removeGitlinksFromIndex(git, 'default-user/extensions/');
 
+            // 暂存并提交
             await git.add('.');
             const status = await git.status();
             const hasChanges = !status.isClean();
@@ -1071,7 +1707,7 @@ async function performAutoSave() {
                 const commitMessage = `Auto Save Overwrite: ${targetTag}`;
                 try {
                     const commitResult = await git.commit(commitMessage);
-                     newCommitHash = commitResult.commit;
+                    newCommitHash = commitResult.commit;
                     try { await git.push('origin', branchToUse); } catch (pushCommitError) {}
                 } catch (commitError) {
                     if (commitError.message.includes('nothing to commit')) {
@@ -1085,72 +1721,142 @@ async function performAutoSave() {
             await unmaskNestedGit(maskedPaths);
         }
 
-        if (!newCommitHash) throw new Error('無法確定用於自動存檔的提交哈希');
+        if (!newCommitHash) throw new Error('无法确定用于自动存档的提交哈希');
 
+        // 删除旧标签（本地和远程）
         try { await git.tag(['-d', targetTag]); } catch (delLocalErr) {}
         try { await git.push(['origin', `:refs/tags/${targetTag}`]); } catch (delRemoteErr) {}
 
+        // 创建新标签指向新的提交
         const nowTimestampOverwrite = new Date().toISOString();
         const fullTagMessageOverwrite = `${originalDescription}\nLast Updated: ${nowTimestampOverwrite}`;
         await git.addAnnotatedTag(targetTag, fullTagMessageOverwrite, newCommitHash);
 
+        // 推送新标签
         try {
-             await git.push('origin', targetTag);
+            await git.push('origin', targetTag);
         } catch (pushTagError) {
-             await git.tag(['-d', targetTag]);
-             throw pushTagError;
+            // 推送失败：清理本地标签
+            await git.tag(['-d', targetTag]);
+            throw pushTagError;
         }
-        console.log(`[Cloud Saves Auto] 成功自動覆蓋存檔: ${targetTag}`);
+        console.log(`[Cloud Saves Auto] 成功自动覆盖存档: ${targetTag}`);
 
     } catch (error) {
-        console.error(`[Cloud Saves Auto] 自動存檔失敗 (mode: ${config?.autoSaveMode}, tag: ${config?.autoSaveTargetTag}):`, error);
+        console.error(`[Cloud Saves Auto] 自动存档失败 (mode: ${config?.autoSaveMode}, tag: ${config?.autoSaveTargetTag}):`, error);
     } finally {
         currentOperation = null;
     }
 }
 
+/**
+ * setupBackendAutoSaveTimer - 设置/重建后端定时存档计时器
+ * 
+ * 逻辑：
+ *   1. 清除现有的计时器（如果有）
+ *   2. 读取配置，检查是否启用了自动存档
+ *   3. 覆盖模式需要目标标签，否则不启动
+ *   4. 计算间隔时间（最小 1 分钟，默认 30 分钟）
+ *   5. 使用 setInterval 创建新的定时器
+ * 
+ * 注意：当配置更改时需要调用此函数来更新定时器
+ */
 function setupBackendAutoSaveTimer() {
+    // 清除现有定时器
     if (autoSaveBackendTimer) {
         clearInterval(autoSaveBackendTimer);
         autoSaveBackendTimer = null;
     }
 
+    // 读取配置并决定是否启动新定时器
     readConfig().then(config => {
         if (config.is_authorized && config.autoSaveEnabled) {
             const mode = config.autoSaveMode || 'overwrite';
-            // 創建模式不需要 targetTag，覆蓋模式需要
+            // 覆盖模式需要 targetTag
             if (mode === 'overwrite' && !config.autoSaveTargetTag) {
-                console.log('[Cloud Saves] 覆蓋模式需要目標標籤，自動存檔定時器不會啟動');
+                console.log('[Cloud Saves] 覆盖模式需要目标标签，自动存档定时器不会启动');
                 return;
             }
+            // 计算间隔（毫秒），确保最少 1 分钟
             let intervalMilliseconds = (config.autoSaveInterval > 0 ? config.autoSaveInterval : 30) * 60 * 1000;
             if (intervalMilliseconds < 60000) intervalMilliseconds = 60000;
+            
             autoSaveBackendTimer = setInterval(performAutoSave, intervalMilliseconds);
-            console.log(`[Cloud Saves] 自動存檔定時器已啟動 (模式: ${mode}, 間隔: ${config.autoSaveInterval}分鐘)`);
+            console.log(`[Cloud Saves] 自动存档定时器已启动 (模式: ${mode}, 间隔: ${config.autoSaveInterval}分钟)`);
         }
     }).catch(err => {
-        console.error('[Cloud Saves] 啟動後端定時器前讀取配置失敗:', err);
+        console.error('[Cloud Saves] 启动后端定时器前读取配置失败:', err);
     });
 }
 
+// =========================== 插件初始化 (主入口) ===========================
+
+/**
+ * init - 插件初始化函数
+ * 
+ * 这是 SillyTavern 加载插件时调用的主函数。
+ * 负责注册所有 HTTP API 路由端点。
+ * 
+ * API 端点列表：
+ * 
+ *   插件元信息：
+ *     GET  /info                    - 获取插件元信息
+ *   
+ *   配置管理：
+ *     GET  /config                  - 获取当前配置（隐藏敏感信息）
+ *     POST /config                  - 更新配置
+ *   
+ *   授权：
+ *     POST /authorize               - 授权并连接 GitHub 仓库
+ *   
+ *   状态查询：
+ *     GET  /status                  - 获取 Git 仓库状态
+ *   
+ *   存档操作：
+ *     GET  /saves                   - 获取存档列表
+ *     POST /saves                   - 创建新存档
+ *     POST /saves/load              - 加载存档
+ *     DELETE /saves/:tagName        - 删除存档
+ *     PUT  /saves/:oldTagName       - 重命名存档
+ *     GET  /saves/diff              - 获取两个存档的差异
+ *     POST /saves/:tagName/overwrite - 覆盖已有存档
+ *   
+ *   Stash 管理：
+ *     POST /stash/apply             - 应用临时 stash
+ *     POST /stash/discard           - 丢弃临时 stash
+ *   
+ *   工具：
+ *     POST /update/check-and-pull   - 检查并拉取插件更新
+ *     POST /initialize              - 强制重新初始化仓库
+ * 
+ * @param {object} router - SillyTavern 注入的 Express 路由器
+ */
 async function init(router) {
     console.log('[cloud-saves] 初始化云存档插件 (simple-git)...');
     console.log('[cloud-saves] 插件 UI 访问地址 (如果端口不是8000请自行修改): http://127.0.0.1:8000/api/plugins/cloud-saves/ui');
 
     try {
+        // ======== 静态文件与基本路由 ========
+        // 提供 public 目录下的静态文件（CSS、JS 等）
         router.use('/static', express.static(path.join(__dirname, 'public')));
+        // 解析 JSON 请求体
         router.use(express.json());
+
+        // 插件 UI 页面
         router.get('/ui', (req, res) => {
             res.sendFile(path.join(__dirname, 'public', 'index.html'));
         });
 
+        // ======== 插件信息 ========
         router.get('/info', (req, res) => {
             res.json(info);
         });
 
+        // ======== 配置读取 ========
         router.get('/config', async (req, res) => {
             try {
                 const config = await readConfig();
+                // 返回安全的配置信息（隐藏敏感数据如 github_token）
                 const safeConfig = {
                     repo_url: config.repo_url || '',
                     display_name: config.display_name || '',
@@ -1162,7 +1868,7 @@ async function init(router) {
                     autoSaveTargetTag: config.autoSaveTargetTag || '',
                     autoSaveMode: config.autoSaveMode || 'overwrite',
                     autoSaveTimezoneOffset: config.autoSaveTimezoneOffset || 0,
-                    has_github_token: !!config.github_token,
+                    has_github_token: !!config.github_token,  // 只告知是否存在 token
                 };
                 res.json(safeConfig);
             } catch (error) {
@@ -1170,14 +1876,17 @@ async function init(router) {
             }
         });
 
+        // ======== 配置更新 ========
         router.post('/config', async (req, res) => {
             try {
                 const {
                     repo_url, github_token, display_name, branch, is_authorized,
-                    autoSaveEnabled, autoSaveInterval, autoSaveTargetTag, autoSaveMode, autoSaveTimezoneOffset
+                    autoSaveEnabled, autoSaveInterval, autoSaveTargetTag, 
+                    autoSaveMode, autoSaveTimezoneOffset
                 } = req.body;
                 let currentConfig = await readConfig();
 
+                // 逐一更新配置字段（只有请求体中有的字段才更新）
                 currentConfig.repo_url = repo_url !== undefined ? repo_url.trim() : currentConfig.repo_url;
                 if (github_token) currentConfig.github_token = github_token;
                 currentConfig.display_name = display_name !== undefined ? display_name.trim() : currentConfig.display_name;
@@ -1185,9 +1894,12 @@ async function init(router) {
                 if (is_authorized !== undefined) currentConfig.is_authorized = !!is_authorized;
                 if (autoSaveEnabled !== undefined) currentConfig.autoSaveEnabled = !!autoSaveEnabled;
                 
+                // 验证自动存档间隔
                 if (autoSaveInterval !== undefined) {
                     const interval = parseFloat(autoSaveInterval);
-                    if (isNaN(interval) || interval <= 0) return res.status(400).json({ success: false, message: '无效的自动存档间隔。' });
+                    if (isNaN(interval) || interval <= 0) {
+                        return res.status(400).json({ success: false, message: '无效的自动存档间隔。' });
+                    }
                     currentConfig.autoSaveInterval = interval;
                 }
                 
@@ -1196,8 +1908,10 @@ async function init(router) {
                 if (autoSaveTimezoneOffset !== undefined) currentConfig.autoSaveTimezoneOffset = parseInt(autoSaveTimezoneOffset) || 0;
 
                 await saveConfig(currentConfig);
+                // 配置更新后重建定时器
                 setupBackendAutoSaveTimer();
 
+                // 返回安全配置
                 const safeConfig = {
                     repo_url: currentConfig.repo_url,
                     display_name: currentConfig.display_name,
@@ -1216,82 +1930,110 @@ async function init(router) {
             }
         });
 
+        // ======== 授权端点 ========
         router.post('/authorize', async (req, res) => {
-             let authGit; 
+            let authGit;
             try {
                 const { branch } = req.body;
                 let config = await readConfig();
                 const targetBranch = branch || config.branch || DEFAULT_BRANCH;
 
+                // 验证必要配置
                 if (!config.repo_url || !config.github_token) {
-                    return res.status(400).json({ success: false, message: '仓库URL和GitHub Token未配置' });
+                    return res.status(400).json({ 
+                        success: false, 
+                        message: '仓库URL和GitHub Token未配置' 
+                    });
                 }
 
                 if (branch && config.branch !== targetBranch) config.branch = targetBranch;
                 config.is_authorized = false;
 
+                // 初始化 Git 仓库
                 const initResult = await initGitRepo();
                 if (!initResult.success) {
-                    return res.status(500).json({ success: false, message: initResult.message, details: initResult.details });
+                    return res.status(500).json({ 
+                        success: false, 
+                        message: initResult.message, 
+                        details: initResult.details 
+                    });
                 }
                 
                 authGit = simpleGit(DATA_DIR);
 
+                // 如果有未追踪的文件，创建初始提交
                 try {
-                     await authGit.add('.');
-                     const status = await authGit.status();
-                     if (!status.isClean()) {
-                         try {
-                             await authGit.addConfig('user.name', 'Cloud Saves Plugin', false, 'local');
-                             await authGit.addConfig('user.email', 'cloud-saves@plugin.local', false, 'local');
-                         } catch (configError) {}
-                         await authGit.commit('Initial commit of existing data directory');
-                     }
-                 } catch (initialCommitError) {}
+                    await authGit.add('.');
+                    const status = await authGit.status();
+                    if (!status.isClean()) {
+                        // 设置 Git 用户名和邮箱（仅在本地有效）
+                        try {
+                            await authGit.addConfig('user.name', 'Cloud Saves Plugin', false, 'local');
+                            await authGit.addConfig('user.email', 'cloud-saves@plugin.local', false, 'local');
+                        } catch (configError) {}
+                        await authGit.commit('Initial commit of existing data directory');
+                    }
+                } catch (initialCommitError) {}
 
+                // 配置远程仓库 URL（嵌入认证 token）
                 let authUrl = config.repo_url;
                 if (config.repo_url.startsWith('https://') && !config.repo_url.includes('@')) {
-                    authUrl = config.repo_url.replace('https://', `https://x-access-token:${config.github_token}@`);
+                    authUrl = config.repo_url.replace('https://', 
+                        `https://x-access-token:${config.github_token}@`);
                 }
                 const remotes = await authGit.getRemotes(true);
                 const origin = remotes.find(r => r.name === 'origin');
                 if (origin) {
-                     if (origin.refs.push !== authUrl) await authGit.remote(['set-url', 'origin', authUrl]);
-                } else await authGit.addRemote('origin', authUrl);
+                    if (origin.refs.push !== authUrl) await authGit.remote(['set-url', 'origin', authUrl]);
+                } else {
+                    await authGit.addRemote('origin', authUrl);
+                }
 
+                // 尝试拉取远程仓库（验证连接和权限）
                 try {
                     await authGit.fetch(['origin', '--tags', '--prune', '--force']);
                 } catch(fetchError) {
-                     await saveConfig(config);
-                     return res.status(400).json({
-                         success: false,
-                         message: '配置错误或权限不足：无法访问远程仓库或获取标签。',
-                         details: fetchError.message
-                     });
+                    await saveConfig(config);
+                    return res.status(400).json({
+                        success: false,
+                        message: '配置错误或权限不足：无法访问远程仓库或获取标签。',
+                        details: fetchError.message
+                    });
                 }
                 
+                // 检查远程分支是否存在
                 let remoteBranchExists = false;
-                 try {
-                     const remoteHeads = await authGit.listRemote(['--heads', 'origin', targetBranch]);
-                     remoteBranchExists = typeof remoteHeads === 'string' && remoteHeads.includes(`refs/heads/${targetBranch}`);
-                 } catch (lsRemoteError) {}
+                try {
+                    const remoteHeads = await authGit.listRemote(['--heads', 'origin', targetBranch]);
+                    remoteBranchExists = typeof remoteHeads === 'string' && 
+                                        remoteHeads.includes(`refs/heads/${targetBranch}`);
+                } catch (lsRemoteError) {}
 
+                // 如果远程分支不存在，创建并推送
                 if (!remoteBranchExists) {
                     try {
                         const localBranches = await authGit.branchLocal();
-                         if (!localBranches.all.includes(targetBranch)) await authGit.checkout(['-b', targetBranch]); 
-                         else await authGit.checkout(targetBranch);
-                         
+                        if (!localBranches.all.includes(targetBranch)) {
+                            await authGit.checkout(['-b', targetBranch]);
+                        } else {
+                            await authGit.checkout(targetBranch);
+                        }
                         await authGit.push(['--set-upstream', 'origin', targetBranch]);
                     } catch (createBranchError) {
-                         await saveConfig(config);
-                         return res.status(500).json({ success: false, message: `無法建立同步分支 ${targetBranch}`, details: createBranchError.message });
+                        await saveConfig(config);
+                        return res.status(500).json({ 
+                            success: false, 
+                            message: `无法建立同步分支 ${targetBranch}`, 
+                            details: createBranchError.message 
+                        });
                     }
                 }
 
+                // 标记授权成功
                 config.is_authorized = true;
                 config.branch = targetBranch;
 
+                // 通过 GitHub API 验证 token 并获取用户名
                 try {
                     const validationResponse = await fetch('https://api.github.com/user', {
                         headers: { 'Authorization': `token ${config.github_token}` }
@@ -1303,8 +2045,10 @@ async function init(router) {
                 } catch (fetchUserError) {}
 
                 await saveConfig(config);
+                // 启动自动存档定时器
                 setupBackendAutoSaveTimer();
 
+                // 返回安全配置
                 const safeConfig = {
                     repo_url: config.repo_url,
                     display_name: config.display_name,
@@ -1321,27 +2065,47 @@ async function init(router) {
                 res.json({ success: true, message: '授权和配置成功', config: safeConfig });
 
             } catch (error) {
-                 try {
-                      let cfg = await readConfig();
-                      cfg.is_authorized = false;
-                      await saveConfig(cfg);
-                 } catch (saveErr) {}
-                res.status(500).json({ success: false, message: '授权过程中发生错误', error: error.message });
+                // 错误处理：取消授权标记
+                try {
+                    let cfg = await readConfig();
+                    cfg.is_authorized = false;
+                    await saveConfig(cfg);
+                } catch (saveErr) {}
+                res.status(500).json({ 
+                    success: false, 
+                    message: '授权过程中发生错误', 
+                    error: error.message 
+                });
             }
         });
 
+        // ======== 状态查询 ========
         router.get('/status', async (req, res) => {
             try {
                 const status = await getGitStatus();
                 const tempStashStatus = await checkTempStash();
-                res.json({ success: true, status: { ...status, tempStash: tempStashStatus } });
+                res.json({ 
+                    success: true, 
+                    status: { ...status, tempStash: tempStashStatus } 
+                });
             } catch (error) {
-                res.status(500).json({ success: false, message: error.message || '获取状态失败', details: error.details });
+                res.status(500).json({ 
+                    success: false, 
+                    message: error.message || '获取状态失败', 
+                    details: error.details 
+                });
             }
         });
 
+        // ======== 存档列表 ========
         router.get('/saves', async (req, res) => {
-            if (currentOperation) return res.status(409).json({ success: false, message: `正在进行操作: ${currentOperation}` });
+            // 如果有操作正在执行，返回 409 冲突
+            if (currentOperation) {
+                return res.status(409).json({ 
+                    success: false, 
+                    message: `正在进行操作: ${currentOperation}` 
+                });
+            }
             try {
                 const result = await listSaves();
                 res.json(result);
@@ -1350,103 +2114,210 @@ async function init(router) {
             }
         });
 
+        // ======== 创建存档 ========
         router.post('/saves', async (req, res) => {
-            if (currentOperation) return res.status(409).json({ success: false, message: `正在进行操作: ${currentOperation}` });
+            if (currentOperation) {
+                return res.status(409).json({ 
+                    success: false, 
+                    message: `正在进行操作: ${currentOperation}` 
+                });
+            }
             try {
                 const { name, description } = req.body;
-                if (!name) return res.status(400).json({ success: false, message: '需要提供存档名称' });
+                if (!name) {
+                    return res.status(400).json({ 
+                        success: false, 
+                        message: '需要提供存档名称' 
+                    });
+                }
                 const result = await createSave(name, description);
                 res.json(result);
             } catch (error) {
-                 res.status(500).json({ success: false, message: '创建存档时发生意外错误', details: error.message });
+                res.status(500).json({ 
+                    success: false, 
+                    message: '创建存档时发生意外错误', 
+                    details: error.message 
+                });
             }
         });
 
+        // ======== 加载存档 ========
         router.post('/saves/load', async (req, res) => {
-            if (currentOperation) return res.status(409).json({ success: false, message: `正在进行操作: ${currentOperation}` });
+            if (currentOperation) {
+                return res.status(409).json({ 
+                    success: false, 
+                    message: `正在进行操作: ${currentOperation}` 
+                });
+            }
             try {
                 const { tagName } = req.body;
-                if (!tagName) return res.status(400).json({ success: false, message: '需要提供存档标签名' });
+                if (!tagName) {
+                    return res.status(400).json({ 
+                        success: false, 
+                        message: '需要提供存档标签名' 
+                    });
+                }
                 const result = await loadSave(tagName);
                 res.json(result);
             } catch (error) {
-                res.status(500).json({ success: false, message: '加载存档时发生意外错误', details: error.message });
+                res.status(500).json({ 
+                    success: false, 
+                    message: '加载存档时发生意外错误', 
+                    details: error.message 
+                });
             }
         });
 
+        // ======== 删除存档 ========
         router.delete('/saves/:tagName', async (req, res) => {
-            if (currentOperation) return res.status(409).json({ success: false, message: `正在进行操作: ${currentOperation}` });
+            if (currentOperation) {
+                return res.status(409).json({ 
+                    success: false, 
+                    message: `正在进行操作: ${currentOperation}` 
+                });
+            }
             try {
                 const { tagName } = req.params;
-                if (!tagName) return res.status(400).json({ success: false, message: '需要提供存档标签名' });
+                if (!tagName) {
+                    return res.status(400).json({ 
+                        success: false, 
+                        message: '需要提供存档标签名' 
+                    });
+                }
                 const result = await deleteSave(tagName);
                 res.json(result);
             } catch (error) {
-                res.status(500).json({ success: false, message: '删除存档时发生意外错误', details: error.message });
+                res.status(500).json({ 
+                    success: false, 
+                    message: '删除存档时发生意外错误', 
+                    details: error.message 
+                });
             }
         });
 
+        // ======== 重命名存档 ========
         router.put('/saves/:oldTagName', async (req, res) => {
-            if (currentOperation) return res.status(409).json({ success: false, message: `正在进行操作: ${currentOperation}` });
+            if (currentOperation) {
+                return res.status(409).json({ 
+                    success: false, 
+                    message: `正在进行操作: ${currentOperation}` 
+                });
+            }
             try {
                 const { oldTagName } = req.params;
                 const { newName, description } = req.body;
-                if (!oldTagName || !newName) return res.status(400).json({ success: false, message: '需要提供旧存档标签名和新名称' });
+                if (!oldTagName || !newName) {
+                    return res.status(400).json({ 
+                        success: false, 
+                        message: '需要提供旧存档标签名和新名称' 
+                    });
+                }
                 const result = await renameSave(oldTagName, newName, description);
                 res.json(result);
             } catch (error) {
-                res.status(500).json({ success: false, message: '重命名存档时发生意外错误', details: error.message });
+                res.status(500).json({ 
+                    success: false, 
+                    message: '重命名存档时发生意外错误', 
+                    details: error.message 
+                });
             }
         });
 
+        // ======== 存档差异 ========
         router.get('/saves/diff', async (req, res) => {
-            if (currentOperation) return res.status(409).json({ success: false, message: `正在进行操作: ${currentOperation}` });
+            if (currentOperation) {
+                return res.status(409).json({ 
+                    success: false, 
+                    message: `正在进行操作: ${currentOperation}` 
+                });
+            }
             try {
                 const { tag1, tag2 } = req.query;
-                if (!tag1 || !tag2) return res.status(400).json({ success: false, message: '需要提供两个存档标签名/引用' });
+                if (!tag1 || !tag2) {
+                    return res.status(400).json({ 
+                        success: false, 
+                        message: '需要提供两个存档标签名/引用' 
+                    });
+                }
                 const result = await getSaveDiff(tag1, tag2);
                 res.json(result);
             } catch (error) {
-                res.status(500).json({ success: false, message: '获取存档差异时发生意外错误', details: error.message });
+                res.status(500).json({ 
+                    success: false, 
+                    message: '获取存档差异时发生意外错误', 
+                    details: error.message 
+                });
             }
         });
 
+        // ======== 应用临时 Stash ========
         router.post('/stash/apply', async (req, res) => {
-            if (currentOperation) return res.status(409).json({ success: false, message: `正在进行操作: ${currentOperation}` });
+            if (currentOperation) {
+                return res.status(409).json({ 
+                    success: false, 
+                    message: `正在进行操作: ${currentOperation}` 
+                });
+            }
             try {
                 const result = await applyTempStash();
                 res.json(result);
             } catch (error) {
-                res.status(500).json({ success: false, message: '应用临时Stash时发生意外错误', details: error.message });
+                res.status(500).json({ 
+                    success: false, 
+                    message: '应用临时Stash时发生意外错误', 
+                    details: error.message 
+                });
             }
         });
 
+        // ======== 丢弃临时 Stash ========
         router.post('/stash/discard', async (req, res) => {
-            if (currentOperation) return res.status(409).json({ success: false, message: `正在进行操作: ${currentOperation}` });
+            if (currentOperation) {
+                return res.status(409).json({ 
+                    success: false, 
+                    message: `正在进行操作: ${currentOperation}` 
+                });
+            }
             try {
                 const result = await discardTempStash();
                 res.json(result);
             } catch (error) {
-                res.status(500).json({ success: false, message: '丢弃临时Stash时发生意外错误', details: error.message });
+                res.status(500).json({ 
+                    success: false, 
+                    message: '丢弃临时Stash时发生意外错误', 
+                    details: error.message 
+                });
             }
         });
 
+        // ======== 覆盖存档 ========
         router.post('/saves/:tagName/overwrite', async (req, res) => {
-            if (currentOperation) return res.status(409).json({ success: false, message: `正在进行操作: ${currentOperation}` });
+            if (currentOperation) {
+                return res.status(409).json({ 
+                    success: false, 
+                    message: `正在进行操作: ${currentOperation}` 
+                });
+            }
             currentOperation = 'overwrite_save';
             const { tagName } = req.params;
             let git;
             try {
                 const config = await readConfig();
-                if (!config.is_authorized) return res.status(401).json({ success: false, message: '未授权，请先连接仓库' });
+                if (!config.is_authorized) {
+                    return res.status(401).json({ 
+                        success: false, 
+                        message: '未授权，请先连接仓库' 
+                    });
+                }
                 
                 git = await getGitInstance();
                 const branchToUse = config.branch || DEFAULT_BRANCH;
 
+                // 读取原有标签描述
                 let originalDescription = `Overwrite of ${tagName}`;
                 try {
-                     const tagInfoRaw = await git.raw('tag', '-n1', '-l', tagName, '--format=%(contents)');
-                     if (tagInfoRaw) originalDescription = tagInfoRaw.trim().split('\n')[0];
+                    const tagInfoRaw = await git.raw('tag', '-n1', '-l', tagName, '--format=%(contents)');
+                    if (tagInfoRaw) originalDescription = tagInfoRaw.trim().split('\n')[0];
                 } catch (tagInfoError) {}
 
                 await ensureGitignoreHidden();
@@ -1455,9 +2326,11 @@ async function init(router) {
                 let newCommitHash;
 
                 try {
+                    // 屏蔽嵌套 Git 目录
                     maskedPaths = await maskNestedGit(extensionsPath);
                     await removeGitlinksFromIndex(git, 'default-user/extensions/');
 
+                    // 暂存并提交
                     await git.add('.');
                     const status = await git.status();
                     const hasChanges = !status.isClean();
@@ -1468,9 +2341,9 @@ async function init(router) {
                             newCommitHash = commitResult.commit;
                             try { await git.push('origin', branchToUse); } catch (pushCommitError) {}
                         } catch (commitError) {
-                             if (commitError.message.includes('nothing to commit')) {
-                                 newCommitHash = await git.revparse('HEAD');
-                             } else throw commitError;
+                            if (commitError.message.includes('nothing to commit')) {
+                                newCommitHash = await git.revparse('HEAD');
+                            } else throw commitError;
                         }
                     } else {
                         newCommitHash = await git.revparse('HEAD');
@@ -1479,8 +2352,9 @@ async function init(router) {
                     await unmaskNestedGit(maskedPaths);
                 }
 
-                 if (!newCommitHash) throw new Error('无法确定用于覆盖的提交哈希');
+                if (!newCommitHash) throw new Error('无法确定用于覆盖的提交哈希');
 
+                // 删除旧标签并创建新标签
                 try { await git.tag(['-d', tagName]); } catch(e) {}
                 try { await git.push(['origin', `:refs/tags/${tagName}`]); } catch (delRemoteErr) {}
 
@@ -1491,23 +2365,33 @@ async function init(router) {
                 try {
                     await git.push('origin', tagName);
                 } catch (pushTagError) {
-                     await git.tag(['-d', tagName]);
-                     throw pushTagError;
+                    await git.tag(['-d', tagName]);
+                    throw pushTagError;
                 }
                 
                 res.json({ success: true, message: '存档覆盖成功', tag: tagName });
 
             } catch (error) {
-                res.status(500).json({ success: false, message: '覆盖存档时发生意外错误', details: error.message });
+                res.status(500).json({ 
+                    success: false, 
+                    message: '覆盖存档时发生意外错误', 
+                    details: error.message 
+                });
             } finally {
                 currentOperation = null;
             }
         });
 
-        // 處理插件檢查更新與拉取
+        // ======== 检查并拉取插件更新 ========
         router.post('/update/check-and-pull', async (req, res) => {
-            if (currentOperation) return res.status(409).json({ success: false, message: `正在进行操作: ${currentOperation}` });
+            if (currentOperation) {
+                return res.status(409).json({ 
+                    success: false, 
+                    message: `正在进行操作: ${currentOperation}` 
+                });
+            }
             try {
+                // 使用插件自身的目录作为 Git 仓库来检查更新
                 const pluginGit = simpleGit(__dirname);
                 const isRepo = await pluginGit.checkIsRepo();
                 
@@ -1522,37 +2406,58 @@ async function init(router) {
                     return res.json({ success: true, status: 'latest' });
                 }
 
+                // 有更新：执行拉取
                 await pluginGit.pull();
                 return res.json({ success: true, status: 'updated' });
             } catch (error) {
                 console.error('[cloud-saves] 检查更新失败:', error);
-                res.status(500).json({ success: false, message: '检查更新过程发生错误', details: error.message });
+                res.status(500).json({ 
+                    success: false, 
+                    message: '检查更新过程发生错误', 
+                    details: error.message 
+                });
             }
         });
 
-        // 處理強制初始化倉庫 (對應前端的「初始化倉庫」按鈕)
+        // ======== 强制重新初始化仓库 ========
         router.post('/initialize', async (req, res) => {
-            if (currentOperation) return res.status(409).json({ success: false, message: `正在进行操作: ${currentOperation}` });
+            if (currentOperation) {
+                return res.status(409).json({ 
+                    success: false, 
+                    message: `正在进行操作: ${currentOperation}` 
+                });
+            }
             try {
                 const gitDir = path.join(DATA_DIR, '.git');
-                // 刪除現有的 .git 目錄以實現強制初始化
+                // 删除现有的 .git 目录以实现强制重新初始化
                 await fs.rm(gitDir, { recursive: true, force: true }).catch(() => {});
                 const result = await initGitRepo();
                 res.json(result);
             } catch (error) {
-                res.status(500).json({ success: false, message: '强制初始化仓库失败', details: error.message });
+                res.status(500).json({ 
+                    success: false, 
+                    message: '强制初始化仓库失败', 
+                    details: error.message 
+                });
             }
         });
 
-        // 啟動後台自動存檔計時器
+        // ======== 启动后台自动存档定时器 ========
         setupBackendAutoSaveTimer();
 
     } catch (error) {
         console.error('[cloud-saves] 初始化插件期间发生错误:', error);
     }
-} // 結束 init 函數
+} // 结束 init 函数
 
-// 匯出插件
+// =========================== 导出插件模块 ===========================
+
+/**
+ * 模块导出
+ * SillyTavern 通过 require 加载插件，读取 info 和 init 属性。
+ *   - info: 提供插件的元信息（ID、名称、描述、版本）
+ *   - init: 插件初始化函数，接收 Express 路由器作为参数
+ */
 module.exports = {
     info,
     init

--- a/index.js
+++ b/index.js
@@ -529,7 +529,7 @@ async function listSaves() {
     }
 }
 
-// 新增：用於在 Git Checkout 讀取完畢後，地毯式搜索並還原那些從存檔中被拉取下來的擴展 .git 資訊
+// 新增：用於在 Git Checkout 讀取完畢後，不僅還原被拉下來的擴展 .git 資訊，同時進行 Git 骨架修復
 async function restoreCheckoutGit(targetPath) {
     try {
         const entries = await fs.readdir(targetPath, { withFileTypes: true });
@@ -540,14 +540,33 @@ async function restoreCheckoutGit(targetPath) {
                 if (entry.name === '.git_cloud_hidden') {
                     const originalGit = path.join(targetPath, '.git');
                     try {
-                        // 確保目標是乾淨的，先強制移除可能衝突的空 .git，接著把隱藏的資料夾改回 .git
+                        // 1. 確保目標是乾淨的，先強制移除可能衝突的損壞 .git
                         await fs.rm(originalGit, { recursive: true, force: true }).catch(() => {});
+                        
+                        // 2. 把從存檔拉下來的隱藏檔改回正統的 .git
                         await fs.rename(entryPath, originalGit);
+                        
+                        // 3. 【核心修復機制】手動補齊 Git 運作所需的基礎空目錄！
+                        // 因為 Git 存檔時「不記錄空資料夾」，這會導致還原出來的 .git 壞掉
+                        // 把這些空目錄建回來，Git 就會重新承認這是一個正常的倉庫，SillyTavern 就能更新了
+                        const requiredGitDirs = [
+                            'objects/info',
+                            'objects/pack',
+                            'refs/heads',
+                            'refs/tags',
+                            'branches',
+                            'info'
+                        ];
+                        for (const dirName of requiredGitDirs) {
+                            await fs.mkdir(path.join(originalGit, dirName), { recursive: true }).catch(() => {});
+                        }
+                        
+                        console.log(`[cloud-saves] 成功修復並還原被刪除擴展的 Git 資訊: ${targetPath}`);
                     } catch (e) {
-                        console.error(`[cloud-saves] 無法還原隱藏的 git 目錄 ${entryPath}:`, e);
+                        console.error(`[cloud-saves] 無法還原/修復隱藏的 git 目錄 ${entryPath}:`, e);
                     }
                 } else if (entry.name !== '.git') {
-                    // 只要不是 .git，就繼續往下層資料夾尋找
+                    // 只要不是 .git，就繼續往下層資料夾遞迴探查
                     await restoreCheckoutGit(entryPath);
                 }
             }
@@ -559,7 +578,7 @@ async function restoreCheckoutGit(targetPath) {
     }
 }
 
-// 完整版：修改自原有的 loadSave，加入了全新的掃描防護機制和完整的錯誤恢復
+// 完整版 loadSave，確保呼叫了上述修復機制
 async function loadSave(tagName) {
     try {
         currentOperation = 'load_save';
@@ -597,13 +616,14 @@ async function loadSave(tagName) {
                 return { success: false, message: '获取存档提交哈希失败' };
             }
 
-            // 這一步會拉取舊的擴展與其 .git_cloud_hidden
+            // 這一步會向本地釋放原本已經刪除的擴充（帶有不完整的 .git_cloud_hidden）
             await git.checkout(commit);
 
         } finally {
-            // 1. 還原本來就存在的擴展
+            // 1. 還原本來就持續存在的擴展
             await unmaskNestedGit(maskedPaths);
-            // 2. 地毯式補救措施：主動掃描並還原那些原本被刪除，但在 checkout 後才從存檔裡被復原的幽靈擴展
+            
+            // 2. 地毯式補救措施與 Git 骨架修復：抓出所有從存檔復原的幽靈擴展並修復它們
             await restoreCheckoutGit(extensionsPath); 
         }
 
@@ -621,7 +641,6 @@ async function loadSave(tagName) {
 
     } catch (error) {
         console.error(`[cloud-saves] 載入存檔時發生錯誤:`, error.message);
-        // 如果發生錯誤，嘗試恢復 stash 以還原使用者的工作區
         try {
             const cfg = await readConfig();
             if (cfg.has_temp_stash) {
@@ -629,20 +648,17 @@ async function loadSave(tagName) {
                 await git.stash(['pop']);
                 cfg.has_temp_stash = false;
                 await saveConfig(cfg);
-                console.log('[cloud-saves] 已回退未保存的更改');
             }
         } catch (recoverError) {
-            console.error('[cloud-saves] 錯誤恢復 (stash pop) 失敗:', recoverError.message);
+            console.error('[cloud-saves] 錯誤恢復失敗:', recoverError.message);
         }
         
-        // 如果你的代碼中有 handleGitError 這個幫助函數，就用它；如果沒有，可以直接回傳 JSON
         return { success: false, message: '加载存档失败', details: error.message };
         
     } finally {
         currentOperation = null;
     }
 }
-
 async function deleteSave(tagName) {
     try {
         currentOperation = 'delete_save';

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ const path = require('path');
 const express = require('express');
 const crypto = require('crypto');
 const simpleGit = require('simple-git');
+const GIT_BACKUP_NAME = '_git_cloud_backup'; // 終極破解：不使用點開頭！規避所有 .* 忽略規則
 
 let fetch;
 try {
@@ -102,7 +103,7 @@ async function ensureGitignoreHidden() {
     }
 }
 
-// 核心修復：在隱藏 .git 的同時，強行注入我們的破解規則
+// 1. 隱藏並強行綁架 .git，確保備份無死角
 async function maskNestedGit(targetDir) {
     const maskedPaths = [];
     async function scan(currentDir) {
@@ -112,16 +113,16 @@ async function maskNestedGit(targetDir) {
                 const fullPath = path.join(currentDir, entry.name);
                 if (entry.isDirectory()) {
                     if (entry.name === '.git') {
-                        const hiddenPath = path.join(currentDir, '.git_cloud_hidden');
+                        const hiddenPath = path.join(currentDir, GIT_BACKUP_NAME);
                         try {
-                            // 確保乾淨轉換
+                            // 將真正的 .git 改名，避開點開頭的忽略規則
                             await fs.rm(hiddenPath, { recursive: true, force: true }).catch(() => {});
                             await fs.rename(fullPath, hiddenPath);
                             
-                            // 【破解 1】防誤殺：強行植入最高權限的 .gitignore，突破所有擴展本身的忽略規則，強制備份 config！
-                            await fs.writeFile(path.join(hiddenPath, '.gitignore'), "# Force tracking\n!*");
+                            // 暴力破解：強制在此目錄下植入最強的白名單規則，保證內部設定絕對被追蹤
+                            await fs.writeFile(path.join(hiddenPath, '.gitignore'), "!*\n").catch(() => {});
                             
-                            // 【破解 2】防骨架蒸發：為 Git 核心空目錄植入 .gitkeep，強迫 Git 備份這些血管與神經！
+                            // 補血機制：植入 .gitkeep，確保 Git 的基本造血空資料夾被跟隨打包
                             const keepDirs = ['objects/info', 'objects/pack', 'refs/heads', 'refs/tags', 'branches', 'info'];
                             for (const dir of keepDirs) {
                                 const keepPath = path.join(hiddenPath, dir);
@@ -133,8 +134,15 @@ async function maskNestedGit(targetDir) {
                         } catch (e) {
                             console.error(`[cloud-saves] 無法隱藏 ${fullPath}:`, e);
                         }
-                    } else if (entry.name !== '.git_cloud_hidden') {
-                        // 遞迴尋找下層
+                    } else if (entry.name === '.git_cloud_hidden') {
+                        // 順手把以前遺留的舊存檔架構升級過來
+                        const hiddenPath = path.join(currentDir, GIT_BACKUP_NAME);
+                        try {
+                            await fs.rename(fullPath, hiddenPath);
+                            maskedPaths.push(path.join(currentDir, '.git'));
+                        } catch (e) {}
+                    } else if (entry.name !== GIT_BACKUP_NAME && entry.name !== 'node_modules') {
+                        // 跳過無用目錄加速掃描，遞迴掃描下一層
                         await scan(fullPath);
                     }
                 }
@@ -145,12 +153,12 @@ async function maskNestedGit(targetDir) {
     return maskedPaths;
 }
 
-// 還原時，將我們注入的破解規則一併打掃乾淨
+// 2. 解除綁架時，原封不動還原現存的插件
 async function unmaskNestedGit(maskedPaths) {
     for (const originalGit of maskedPaths) {
-        const hiddenPath = originalGit.replace(/\.git$/, '.git_cloud_hidden');
+        const hiddenPath = originalGit.replace(/\.git$/, GIT_BACKUP_NAME);
         try {
-            // 清理注入的破破解 .gitignore
+            // 清理注入的強制追蹤規則
             await fs.rm(path.join(hiddenPath, '.gitignore'), { force: true }).catch(() => {});
             await fs.rm(originalGit, { recursive: true, force: true }).catch(() => {});
             await fs.rename(hiddenPath, originalGit);
@@ -544,28 +552,31 @@ async function listSaves() {
     }
 }
 
-// 補救讀取被刪除的插件
+// 3. 還原被刪除後、又被 Git Checkout 下來的「復活插件」
 async function restoreCheckoutGit(targetPath) {
     try {
         const entries = await fs.readdir(targetPath, { withFileTypes: true });
         for (const entry of entries) {
             const entryPath = path.join(targetPath, entry.name);
             if (entry.isDirectory()) {
-                if (entry.name === '.git_cloud_hidden') {
+                // 如果抓到了我們的新版備份檔(或是舊版)，就把它改回真正的 .git
+                if (entry.name === GIT_BACKUP_NAME || entry.name === '.git_cloud_hidden') {
                     const originalGit = path.join(targetPath, '.git');
                     try {
                         await fs.rm(originalGit, { recursive: true, force: true }).catch(() => {});
                         await fs.rename(entryPath, originalGit);
-                        // 清理拉取下來的破解檔案
-                        await fs.rm(path.join(originalGit, '.gitignore'), { force: true }).catch(() => {});
                         
-                        // 針對那些「使用舊代碼備份、從未被補救」的舊存檔作最後的骨架重建（盡力挽救舊檔用）
+                        // 清理掉我們強制追蹤的髒東西
+                        await fs.rm(path.join(originalGit, '.gitignore'), { force: true }).catch(() => {});
+                        await fs.rm(path.join(originalGit, '.gitkeep'), { force: true }).catch(() => {}); // 順手清理根目錄可能存在的 gitkeep
+                        
+                        // 保險：強制建立基本空資料夾架構
                         const requiredGitDirs = ['objects/info', 'objects/pack', 'refs/heads', 'refs/tags', 'branches', 'info'];
                         for (const dirName of requiredGitDirs) {
                             await fs.mkdir(path.join(originalGit, dirName), { recursive: true }).catch(() => {});
                         }
                     } catch (e) {}
-                } else if (entry.name !== '.git') {
+                } else if (entry.name !== '.git' && entry.name !== 'node_modules') {
                     await restoreCheckoutGit(entryPath);
                 }
             }
@@ -573,7 +584,7 @@ async function restoreCheckoutGit(targetPath) {
     } catch (error) {}
 }
 
-// 完整版 loadSave，確保呼叫了上述修復機制
+// 4. 完整的 Load Save 處理流程
 async function loadSave(tagName) {
     try {
         currentOperation = 'load_save';
@@ -592,7 +603,7 @@ async function loadSave(tagName) {
         let stashCreated = false;
 
         try {
-            // 切換前，先保護現有的 .git
+            // 切換分支前，保護現有的 .git
             maskedPaths = await maskNestedGit(extensionsPath);
 
             const status = await git.status();
@@ -611,14 +622,12 @@ async function loadSave(tagName) {
                 return { success: false, message: '获取存档提交哈希失败' };
             }
 
-            // 這一步會向本地釋放原本已經刪除的擴充（帶有不完整的 .git_cloud_hidden）
+            // 這一步會向本地覆寫檔案，把舊存檔的 _git_cloud_backup 給放出來
             await git.checkout(commit);
 
         } finally {
-            // 1. 還原本來就持續存在的擴展
+            // 這兩步將無死角還原所有受影響以及「死灰復燃」的插件 .git
             await unmaskNestedGit(maskedPaths);
-            
-            // 2. 地毯式補救措施與 Git 骨架修復：抓出所有從存檔復原的幽靈擴展並修復它們
             await restoreCheckoutGit(extensionsPath); 
         }
 
@@ -654,6 +663,7 @@ async function loadSave(tagName) {
         currentOperation = null;
     }
 }
+
 async function deleteSave(tagName) {
     try {
         currentOperation = 'delete_save';

--- a/index.js
+++ b/index.js
@@ -1317,6 +1317,70 @@ async function init(router) {
             }
         });
 
+                // 1. 新增：处理「检查并更新插件」的后端路由
+        router.post('/update/check-and-pull', async (req, res) => {
+            if (currentOperation) return res.status(409).json({ success: false, message: `正在进行操作: ${currentOperation}` });
+            try {
+                currentOperation = 'update_plugin';
+                const git = simpleGit(__dirname); // 检查插件自身的更新，而不是 DATA_DIR
+                
+                const isRepo = await git.checkIsRepo();
+                if (!isRepo) {
+                    return res.json({ success: true, status: 'not_git_repo', message: '无法自动更新：插件似乎不是通过 Git 安装的。' });
+                }
+
+                await git.fetch();
+                const status = await git.status();
+
+                if (status.behind === 0) {
+                    return res.json({ success: true, status: 'latest', message: '插件已是最新版本。' });
+                }
+
+                await git.pull();
+                res.json({ success: true, status: 'updated', message: '插件更新成功！请务必重启 SillyTavern 服务以应用更改。' });
+            } catch (error) {
+                res.status(500).json({ success: false, message: '检查或应用更新时发生意外错误', details: error.message });
+            } finally {
+                currentOperation = null;
+            }
+        });
+
+        // 2. 新增：处理「强制初始化仓库」的后端路由 (另一个也一并修复)
+        router.post('/initialize', async (req, res) => {
+            if (currentOperation) return res.status(409).json({ success: false, message: `正在进行操作: ${currentOperation}` });
+            try {
+                currentOperation = 'initialize_repo';
+                const gitDir = path.join(DATA_DIR, '.git');
+                const hiddenGitDir = path.join(DATA_DIR, GIT_BACKUP_NAME);
+                
+                // 彻底删除被破坏或旧有遗留的仓库文件以强制重建
+                await fs.rm(gitDir, { recursive: true, force: true }).catch(() => {});
+                await fs.rm(hiddenGitDir, { recursive: true, force: true }).catch(() => {});
+                
+                const initResult = await initGitRepo();
+                
+                if (initResult.success) {
+                    res.json({ success: true, message: '仓库强制初始化成功' });
+                } else {
+                    res.status(500).json({ success: false, message: initResult.message, details: initResult.details });
+                }
+            } catch (error) {
+                res.status(500).json({ success: false, message: '初始化仓库时发生意外错误', details: error.message });
+            } finally {
+                currentOperation = null;
+            }
+        });
+
+        // ================= 新增结束 =================
+
+        // 启动后台自动存档计时器
+        setupBackendAutoSaveTimer();
+
+    } catch (error) {
+        console.error('[cloud-saves] 初始化插件期间发生错误:', error);
+    }
+} // 结束 init 函数
+
         router.delete('/saves/:tagName', async (req, res) => {
             if (currentOperation) return res.status(409).json({ success: false, message: `正在进行操作: ${currentOperation}` });
             try {

--- a/public/index.html
+++ b/public/index.html
@@ -1,11 +1,53 @@
 <!DOCTYPE html>
+<!-- ============================================================================
+     SillyTavern Cloud Saves 插件 - 前端界面 (index.html)
+     ============================================================================
+     
+     页面结构概览：
+       1. 检查更新按钮（页面左上角）
+       2. 页面标题
+       3. 仓库授权设置卡片（输入 URL、Token、分支等）
+       4. 定时自动存档设置卡片（间隔、模式、目标标签）
+       5. 创建新存档卡片（名称和描述输入）
+       6. 存档列表卡片（搜索、排序、展示所有存档）
+       7. 临时 Stash 恢复通知条
+       8. 底部状态栏（Git 状态、当前存档）
+     
+     模态框：
+       - 重命名/编辑存档模态框
+       - 确认操作对话框
+       - 存档差异对比模态框
+     
+     加载覆盖层和通知组件也在本文件中定义。
+     
+     依赖：
+       - Bootstrap 5.2.3 CSS + JS（CDN 引入）
+       - Bootstrap Icons 1.10.3（CDN 引入）
+       - 自定义脚本 script.js（本地加载）
+     
+     语言：简体中文 (zh-CN)
+     ============================================================================
+-->
 <html lang="zh-CN">
 <head>
     <meta charset="UTF-8">
+    <!-- 
+        viewport 设置：确保移动设备上的响应式显示 
+        width=device-width: 视口宽度等于设备宽度
+        initial-scale=1.0: 初始缩放比例为 1:1
+    -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>SillyTavern 云存档</title>
+    
+    <!-- Bootstrap 5 CSS - 提供栅格系统、组件样式和工具类 -->
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css">
+    <!-- Bootstrap Icons - 提供丰富的图标库 (bi-* 类名) -->
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.3/font/bootstrap-icons.min.css">
+    
+    <!-- 
+        内联样式: 在这里定义是因为需要覆盖 Bootstrap 默认变量
+        使用 :root CSS 变量实现主题色统一管理
+    -->
     <style>
         :root {
             --bs-primary: #7c71f5;
@@ -42,288 +84,245 @@
         .card-body {
             padding: 15px;
         }
-        .btn-primary {
-            background-color: var(--bs-primary);
-            border-color: var(--bs-primary);
-        }
-        .btn-success {
-            background-color: var(--bs-success);
-            border-color: var(--bs-success);
-        }
-        .btn-warning {
-            background-color: var(--bs-warning);
-            border-color: var(--bs-warning);
-            color: #202123;
-        }
-        .btn-danger {
-            background-color: var(--bs-danger);
-            border-color: var(--bs-danger);
-        }
-        .save-card {
-            position: relative;
-        }
-        .save-card .action-buttons {
-            display: flex;
-            justify-content: flex-end;
-            gap: 5px;
-        }
-        .save-timestamp {
-            color: #aaaaaa;
-            font-size: 0.9rem;
-        }
-        .save-description {
-            color: #dddddd;
-            margin-top: 8px;
-            white-space: pre-line;
-            max-height: 100px;
-            overflow-y: auto;
-        }
-        .save-current-badge {
-            position: absolute;
-            top: 10px;
-            right: 10px;
-            background-color: var(--bs-primary);
-            color: white;
-            padding: 3px 10px;
-            border-radius: 10px;
-            font-size: 0.8rem;
-            z-index: 10;
-        }
-        .loading-overlay {
-            position: fixed;
-            top: 0;
-            left: 0;
-            width: 100%;
-            height: 100%;
-            background-color: rgba(0, 0, 0, 0.7);
-            display: flex;
-            justify-content: center;
-            align-items: center;
-            z-index: 1000;
-            display: none;
-        }
-        .spinner-container {
-            text-align: center;
-        }
-        .spinner-message {
-            margin-top: 15px;
-            font-size: 1.2rem;
-            color: white;
-        }
-        #auth-section {
-            margin-bottom: 30px;
-        }
-        #saves-container {
-            max-height: 70vh;
-            overflow-y: auto;
-            padding-right: 5px;
-        }
-        #saves-container::-webkit-scrollbar {
-            width: 8px;
-        }
-        #saves-container::-webkit-scrollbar-track {
-            background: #2d2d31;
-            border-radius: 10px;
-        }
-        #saves-container::-webkit-scrollbar-thumb {
-            background: #555555;
-            border-radius: 10px;
-        }
-        #saves-container::-webkit-scrollbar-thumb:hover {
-            background: #777777;
-        }
-        #status-bar {
-            margin-top: 20px;
-            padding: 10px;
-            background-color: #2d2d31;
-            border-radius: 5px;
-            font-size: 0.9rem;
-        }
-        .section-header {
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-            margin-bottom: 15px;
-            padding-bottom: 10px;
-            border-bottom: 1px solid #444444;
-        }
-        .filter-dropdown {
-            max-width: 200px;
-        }
-        #search-box {
-            background-color: #2d2d31;
-            border: 1px solid #444444;
-            color: white;
-        }
-        /* Modal customization */
-        .modal-content {
-            background-color: #2d2d31;
-            color: white;
-            border: 1px solid #444444;
-        }
-        .modal-header {
-            border-bottom: 1px solid #444444;
-        }
-        .modal-footer {
-            border-top: 1px solid #444444;
-        }
-        .form-control, .form-select {
-            background-color: #383838;
-            border: 1px solid #555555;
-            color: white;
-        }
-        .form-control:focus, .form-select:focus {
-            background-color: #3a3a3a;
-            color: white;
-            border-color: var(--bs-primary);
-            box-shadow: 0 0 0 0.25rem rgba(var(--bs-primary-rgb), 0.25);
-        }
-        /* Toast notifications */
-        .toast-container {
-            position: fixed;
-            top: 20px;
-            right: 20px;
-            z-index: 1050;
-        }
-        .toast {
-            background-color: #2d2d31;
-            color: white;
-            border: 1px solid #444444;
-        }
-        .toast-header {
-            background-color: rgba(0, 0, 0, 0.2);
-            color: white;
-            border-bottom: 1px solid #444444;
-        }
-        .empty-state {
-            text-align: center;
-            padding: 50px 20px;
-            color: #aaaaaa;
-        }
-        .empty-state i {
-            font-size: 3rem;
-            margin-bottom: 15px;
-            color: #555555;
-        }
-        .badge-changes {
-            font-size: 0.7rem;
-            padding: 3px 7px;
-            margin-left: 5px;
-            vertical-align: middle;
-            background-color: #555555;
-        }
+        .btn-primary { background-color: var(--bs-primary); border-color: var(--bs-primary); }
+        .btn-success { background-color: var(--bs-success); border-color: var(--bs-success); }
+        .btn-warning { background-color: var(--bs-warning); border-color: var(--bs-warning); color: #202123; }
+        .btn-danger { background-color: var(--bs-danger); border-color: var(--bs-danger); }
+        
+        /* 存档卡片：相对定位，为"当前存档"徽章提供锚点 */
+        .save-card { position: relative; }
+        .save-card .action-buttons { display: flex; justify-content: flex-end; gap: 5px; }
+        .save-timestamp { color: #aaaaaa; font-size: 0.9rem; }
+        .save-description { color: #dddddd; margin-top: 8px; white-space: pre-line; max-height: 100px; overflow-y: auto; }
+        
+        /* "当前存档"角标 */
+        .save-current-badge { position: absolute; top: 10px; right: 10px; background-color: var(--bs-primary); color: white; padding: 3px 10px; border-radius: 10px; font-size: 0.8rem; z-index: 10; }
+        
+        /* 加载遮罩层：固定覆盖全屏 */
+        .loading-overlay { position: fixed; top: 0; left: 0; width: 100%; height: 100%; background-color: rgba(0, 0, 0, 0.7); display: flex; justify-content: center; align-items: center; z-index: 1000; display: none; }
+        .spinner-container { text-align: center; }
+        .spinner-message { margin-top: 15px; font-size: 1.2rem; color: white; }
+        
+        #auth-section { margin-bottom: 30px; }
+        
+        /* 存档列表可滚动区域 */
+        #saves-container { max-height: 70vh; overflow-y: auto; padding-right: 5px; }
+        /* 自定义滚动条 */
+        #saves-container::-webkit-scrollbar { width: 8px; }
+        #saves-container::-webkit-scrollbar-track { background: #2d2d31; border-radius: 10px; }
+        #saves-container::-webkit-scrollbar-thumb { background: #555555; border-radius: 10px; }
+        #saves-container::-webkit-scrollbar-thumb:hover { background: #777777; }
+        
+        #status-bar { margin-top: 20px; padding: 10px; background-color: #2d2d31; border-radius: 5px; font-size: 0.9rem; }
+        .section-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 15px; padding-bottom: 10px; border-bottom: 1px solid #444444; }
+        .filter-dropdown { max-width: 200px; }
+        #search-box { background-color: #2d2d31; border: 1px solid #444444; color: white; }
+        
+        /* 模态框 */
+        .modal-content { background-color: #2d2d31; color: white; border: 1px solid #444444; }
+        .modal-header { border-bottom: 1px solid #444444; }
+        .modal-footer { border-top: 1px solid #444444; }
+        
+        /* 表单控件 */
+        .form-control, .form-select { background-color: #383838; border: 1px solid #555555; color: white; }
+        .form-control:focus, .form-select:focus { background-color: #3a3a3a; color: white; border-color: var(--bs-primary); box-shadow: 0 0 0 0.25rem rgba(var(--bs-primary-rgb), 0.25); }
+        
+        /* Toast 通知 */
+        .toast-container { position: fixed; top: 20px; right: 20px; z-index: 1050; }
+        .toast { background-color: #2d2d31; color: white; border: 1px solid #444444; }
+        .toast-header { background-color: rgba(0, 0, 0, 0.2); color: white; border-bottom: 1px solid #444444; }
+        
+        .empty-state { text-align: center; padding: 50px 20px; color: #aaaaaa; }
+        .empty-state i { font-size: 3rem; margin-bottom: 15px; color: #555555; }
+        .badge-changes { font-size: 0.7rem; padding: 3px 7px; margin-left: 5px; vertical-align: middle; background-color: #555555; }
     </style>
 </head>
 <body>
+    <!-- 
+        主容器
+        - container: Bootstrap 响应式容器
+        - py-4: 上下方向的内边距 (padding-y = 1.5rem)
+    -->
     <div class="container py-4">
-        <!-- 修改：将检查更新按钮移到标题前 -->
+        
+        <!-- =========================== 检查更新按钮 =========================== -->
+        <!-- 位于页面左上角，在标题之前 -->
         <div class="text-start mb-3">
             <button id="check-update-btn" class="btn btn-sm btn-outline-info" title="检查插件更新">
                 <i class="bi bi-cloud-arrow-down-fill"></i> 检查更新
             </button>
         </div>
 
+        <!-- =========================== 页面标题 =========================== -->
         <h1 class="text-center mb-4">
             <i class="bi bi-cloud-arrow-up-down me-2"></i>SillyTavern 云存档
         </h1>
 
-        <!-- 授权设置部分 -->
+        <!-- =========================== 1. 仓库授权设置卡片 =========================== -->
         <div id="auth-section" class="card">
             <div class="card-header">
                 <i class="bi bi-key-fill me-2"></i>仓库授权设置
             </div>
             <div class="card-body">
+                <!-- 
+                    授权表单
+                    包含：仓库 URL、分支名、GitHub Token、显示名称
+                    四个操作按钮：初始化仓库、配置、授权并连接、断开连接
+                -->
                 <div id="auth-form">
+                    <!-- 仓库 URL 输入 -->
                     <div class="mb-3">
                         <label for="repo-url" class="form-label">GitHub 仓库 URL</label>
-                        <input type="url" class="form-control mb-1" id="repo-url" placeholder="https://github.com/your-username/your-repo.git" required>
+                        <input type="url" class="form-control mb-1" id="repo-url" 
+                               placeholder="https://github.com/your-username/your-repo.git" required>
                         <small class="form-text text-muted">请确保仓库已创建且您拥有写入权限</small>
                     </div>
 
-                    <!-- 新增：分支输入框 -->
+                    <!-- 分支输入框（新增功能） -->
                     <div class="mb-3">
                         <label for="branch-input" class="form-label">分支</label>
                         <input type="text" class="form-control" id="branch-input" value="main" placeholder="main">
                         <small class="form-text text-muted">将用于存储存档的分支。如果不存在，将尝试创建。</small>
                     </div>
 
+                    <!-- GitHub 访问令牌输入 -->
                     <div class="mb-3">
                         <label for="github-token" class="form-label">GitHub 访问令牌</label>
+                        <!-- type="password" 隐藏输入的令牌内容 -->
                         <input type="password" class="form-control" id="github-token" placeholder="例如: ghp_xxxxxxxxxxxx">
                         <div class="form-text text-light">
+                            <!-- 链接到 GitHub Token 创建页面 -->
                             <a href="https://github.com/settings/tokens" target="_blank" class="text-info">创建令牌</a>
                             需要具有 repo 权限
                         </div>
                     </div>
+                    
+                    <!-- 显示名称输入（可选） -->
                     <div class="mb-3">
                         <label for="display-name" class="form-label">显示名称（可选）</label>
                         <input type="text" class="form-control" id="display-name" placeholder="用于存档记录的操作人名称">
                         <div class="form-text text-light">如果不设置，将尝试使用GitHub用户名或默认名称</div>
                     </div>
+                    
+                    <!-- 操作按钮组 -->
                     <div class="d-flex gap-2">
-                        <button type="button" class="btn btn-outline-warning" id="init-repo-btn" title="在 data 目录强制执行 git init 并配置远程仓库">
+                        <!-- 
+                            初始化仓库按钮
+                            - btn-outline-warning: 警告色轮廓按钮
+                            - 强制在 data 目录执行 git init 并配置远程仓库
+                        -->
+                        <button type="button" class="btn btn-outline-warning" id="init-repo-btn" 
+                                title="在 data 目录强制执行 git init 并配置远程仓库">
                             <i class="bi bi-hdd-rack-fill me-1"></i>初始化仓库
                         </button>
+                        <!-- 
+                            配置按钮
+                            - btn-secondary: 灰色次要按钮
+                            - 只保存配置信息，不进行授权验证
+                        -->
                         <button type="button" class="btn btn-secondary" id="configure-btn">
                             <i class="bi bi-gear-fill me-1"></i>配置
                         </button>
+                        <!-- 
+                            授权并连接按钮
+                            - btn-primary: 主色调按钮
+                            - 保存配置 + 验证远程连接 + 初始化同步
+                        -->
                         <button type="button" class="btn btn-primary" id="authorize-btn">
                             <i class="bi bi-shield-check me-1"></i>授权并连接
                         </button>
+                        <!-- 
+                            断开连接按钮
+                            - btn-danger: 危险色按钮
+                            - ms-auto: 将按钮推到右侧
+                            - 默认隐藏，授权成功后显示
+                        -->
                         <button type="button" class="btn btn-danger ms-auto" id="logout-btn" style="display: none;">
                             <i class="bi bi-box-arrow-right me-1"></i>断开连接
                         </button>
                     </div>
                 </div>
+                <!-- 
+                    授权状态提示
+                    - alert: Bootstrap 警告框组件
+                    - 默认隐藏，授权成功或失败时显示
+                -->
                 <div id="auth-status" class="alert mt-3" style="display: none;"></div>
             </div>
         </div>
 
-        <!-- 定时存档设置部分 -->
+        <!-- =========================== 2. 定时自动存档设置卡片 =========================== -->
+        <!-- 默认隐藏，授权成功后才显示 -->
         <div id="auto-save-section" class="card mb-4" style="display: none;">
             <div class="card-header">
                 <i class="bi bi-clock-history me-2"></i>定时自动存档设置
             </div>
             <div class="card-body">
+                <!-- 
+                    启用开关
+                    - form-switch: Bootstrap 开关样式
+                    - role="switch": ARIA 无障碍属性
+                -->
                 <div class="form-check form-switch mb-3">
                     <input class="form-check-input" type="checkbox" role="switch" id="auto-save-enabled">
                     <label class="form-check-label" for="auto-save-enabled">启用定时自动存档</label>
                 </div>
+                
+                <!-- 自动存档选项区域：默认隐藏，启用开关后才显示 -->
                 <div class="row g-3" id="auto-save-options" style="display: none;">
+                    <!-- 存档模式选择 -->
                     <div class="col-12 mb-2">
                         <label class="form-label">自动存档模式</label>
+                        <!-- 
+                            btn-group: Bootstrap 按钮组
+                            两个互斥的单选按钮（使用 input[type=radio] + btn-check 技术）
+                        -->
                         <div class="btn-group" role="group" id="auto-save-mode-group">
                             <input type="radio" class="btn-check" name="auto-save-mode" id="auto-save-mode-overwrite" value="overwrite" checked>
                             <label class="btn btn-outline-primary btn-sm" for="auto-save-mode-overwrite">覆盖已有存档</label>
+                            
                             <input type="radio" class="btn-check" name="auto-save-mode" id="auto-save-mode-create" value="create">
                             <label class="btn btn-outline-primary btn-sm" for="auto-save-mode-create">创建新存档</label>
                         </div>
-                        <small class="form-text text-muted d-block mt-1" id="auto-save-mode-hint">覆盖模式：每次自动存档将覆盖指定的已有存档标签。</small>
+                        <!-- 模式说明文字：根据选中模式动态变化 -->
+                        <small class="form-text text-muted d-block mt-1" id="auto-save-mode-hint">
+                            覆盖模式：每次自动存档将覆盖指定的已有存档标签。
+                        </small>
                     </div>
+                    
+                    <!-- 存档间隔（分钟） -->
                     <div class="col-md-6">
                         <label for="auto-save-interval" class="form-label">存档间隔（分钟）</label>
                         <input type="number" class="form-control" id="auto-save-interval" min="1" value="30">
                     </div>
+                    
+                    <!-- 覆盖目标标签（仅覆盖模式需要） -->
                     <div class="col-md-6" id="auto-save-target-tag-row">
                         <label for="auto-save-target-tag" class="form-label">覆盖的目标存档标签</label>
                         <input type="text" class="form-control" id="auto-save-target-tag" placeholder="输入要覆盖的存档标签名">
                         <small class="form-text text-muted">必须是已存在的云存档标签名。每次自动存档将覆盖此存档。</small>
                     </div>
                 </div>
-                 <button id="save-auto-save-settings-btn" class="btn btn-sm btn-secondary mt-3">保存定时设置</button>
+                 
+                <!-- 保存定时设置按钮 -->
+                <button id="save-auto-save-settings-btn" class="btn btn-sm btn-secondary mt-3">保存定时设置</button>
             </div>
         </div>
 
-        <!-- 创建新存档部分 -->
+        <!-- =========================== 3. 创建新存档卡片 =========================== -->
+        <!-- 默认隐藏，授权成功后才显示 -->
         <div id="create-save-section" class="card" style="display: none;">
             <div class="card-header">
                 <i class="bi bi-cloud-plus-fill me-2"></i>创建新存档
             </div>
             <div class="card-body">
                 <div class="row g-3">
+                    <!-- 存档名称输入（左列） -->
                     <div class="col-md-6">
-                        <input type="text" class="form-control" id="save-name" placeholder="存档名称（留空则自动命名为「YYYY-MM-DD - HHMM」）">
+                        <input type="text" class="form-control" id="save-name" 
+                               placeholder="存档名称（留空则自动命名为「YYYY-MM-DD - HHMM」)">
                     </div>
+                    <!-- 保存按钮（右列），使用 d-grid 让按钮撑满宽度 -->
                     <div class="col-md-6">
                         <div class="d-grid">
                             <button id="create-save-btn" class="btn btn-success">
@@ -331,6 +330,7 @@
                             </button>
                         </div>
                     </div>
+                    <!-- 存档描述输入（全宽） -->
                     <div class="col-12">
                         <textarea class="form-control" id="save-description" rows="2" placeholder="存档描述（可选）"></textarea>
                     </div>
@@ -338,19 +338,24 @@
             </div>
         </div>
 
-        <!-- 存档列表部分 -->
+        <!-- =========================== 4. 存档列表卡片 =========================== -->
+        <!-- 默认隐藏，授权成功后才显示 -->
         <div id="saves-section" class="card" style="display: none;">
             <div class="card-header">
                 <div class="section-header">
                     <span><i class="bi bi-list-stars me-2"></i>存档列表</span>
+                    <!-- 搜索和排序控件 -->
                     <div class="d-flex gap-2">
+                        <!-- 搜索框 -->
                         <input type="text" class="form-control form-control-sm" id="search-box" placeholder="搜索存档...">
+                        <!-- 排序下拉 -->
                         <select class="form-select form-select-sm filter-dropdown" id="sort-selector">
                             <option value="updated-desc">按更新时间排序 (降序)</option>
                             <option value="updated-asc">按更新时间排序 (升序)</option>
                             <option value="name-asc">名称 (A-Z)</option>
                             <option value="name-desc">名称 (Z-A)</option>
                         </select>
+                        <!-- 刷新按钮 -->
                         <button id="refresh-saves-btn" class="btn btn-sm btn-outline-secondary">
                             <i class="bi bi-arrow-clockwise"></i>
                         </button>
@@ -358,8 +363,9 @@
                 </div>
             </div>
             <div class="card-body">
+                <!-- 存档卡片容器——通过 JS 动态生成存档卡片 -->
                 <div id="saves-container">
-                    <!-- 存档卡片将通过JS动态生成 -->
+                    <!-- 空状态占位：无存档时显示 -->
                     <div class="empty-state" id="no-saves-message">
                         <i class="bi bi-cloud-slash"></i>
                         <h5>没有找到存档</h5>
@@ -369,7 +375,12 @@
             </div>
         </div>
 
-        <!-- 临时保存的工作区恢复通知 -->
+        <!-- =========================== 5. 临时 Stash 恢复通知 =========================== -->
+        <!-- 
+            加载存档时如果有未保存的更改，会自动创建临时 stash。
+            此通知条提示用户可以恢复或丢弃这些更改。
+            默认隐藏。
+        -->
         <div id="stash-notification" class="alert alert-warning mt-3" style="display: none;">
             <i class="bi bi-exclamation-triangle-fill me-2"></i>
             <span>您有切换存档前保存的临时工作区更改。</span>
@@ -379,15 +390,26 @@
             </div>
         </div>
 
-        <!-- 状态栏 -->
+        <!-- =========================== 6. 底部状态栏 =========================== -->
         <div id="status-bar">
             <div class="d-flex justify-content-between align-items-center">
+                <!-- 左侧：Git 状态和变更数量 -->
                 <div>
+                    <!-- 
+                        Git 仓库状态指示器
+                        - 灰点表示未初始化
+                        - 绿点 (text-success) 表示已就绪
+                    -->
                     <span id="git-status"><i class="bi bi-circle-fill text-secondary me-2"></i>未初始化</span>
+                    <!-- 
+                        未保存变更数量
+                        - 默认隐藏，有变更时才显示
+                    -->
                     <span id="changes-status" class="ms-3" style="display: none;">
                         <i class="bi bi-pencil-fill text-warning me-1"></i><span id="changes-count">0</span> 个未保存的更改
                     </span>
                 </div>
+                <!-- 右侧：当前加载的存档信息 -->
                 <div>
                     <span id="current-save-status">未加载任何存档</span>
                 </div>
@@ -395,15 +417,23 @@
         </div>
     </div>
 
-    <!-- 重命名/编辑模态框 -->
+    <!-- =========================== 模态框 1: 重命名/编辑存档 =========================== -->
+    <!-- 
+        Bootstrap Modal 组件
+        - fade: 淡入淡出动画
+        - modal-dialog: 居中对话框
+        - 用于编辑存档名称和描述
+    -->
     <div class="modal fade" id="renameModal" tabindex="-1" aria-labelledby="renameModalLabel" aria-hidden="true">
         <div class="modal-dialog">
             <div class="modal-content">
                 <div class="modal-header">
                     <h5 class="modal-title" id="renameModalLabel">重命名存档</h5>
+                    <!-- btn-close-white: 白色关闭按钮，适配暗色背景 -->
                     <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
                 </div>
                 <div class="modal-body">
+                    <!-- 隐藏字段：保存被编辑的存档标签名 -->
                     <input type="hidden" id="rename-tag-name">
                     <div class="mb-3">
                         <label for="rename-new-name" class="form-label">存档名称</label>
@@ -422,7 +452,12 @@
         </div>
     </div>
 
-    <!-- 确认对话框 -->
+    <!-- =========================== 模态框 2: 确认操作对话框 =========================== -->
+    <!-- 
+        通用确认对话框，用于删除、覆盖等危险操作前的二次确认
+        - 消息内容动态设置
+        - 确认按钮类型动态设置（btn-danger/btn-primary 等）
+    -->
     <div class="modal fade" id="confirmModal" tabindex="-1" aria-labelledby="confirmModalLabel" aria-hidden="true">
         <div class="modal-dialog">
             <div class="modal-content">
@@ -430,6 +465,7 @@
                     <h5 class="modal-title" id="confirmModalLabel">确认操作</h5>
                     <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
                 </div>
+                <!-- 消息文本动态填充 -->
                 <div class="modal-body" id="confirm-message">
                     您确定要执行此操作吗？
                 </div>
@@ -441,7 +477,12 @@
         </div>
     </div>
 
-    <!-- 差异比较模态框 -->
+    <!-- =========================== 模态框 3: 存档差异对比 =========================== -->
+    <!-- 
+        显示两个存档之间的文件差异
+        - modal-lg: 大尺寸模态框（因为有文件列表）
+        - 显示变更摘要和文件列表
+    -->
     <div class="modal fade" id="diffModal" tabindex="-1" aria-labelledby="diffModalLabel" aria-hidden="true">
         <div class="modal-dialog modal-lg">
             <div class="modal-content">
@@ -450,8 +491,10 @@
                     <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
                 </div>
                 <div class="modal-body">
+                    <!-- 差异摘要区域 -->
                     <div class="diff-summary mb-3" id="diff-summary"></div>
                     <h6>更改文件列表:</h6>
+                    <!-- 变更文件列表区域 -->
                     <div class="diff-files" id="diff-files"></div>
                 </div>
                 <div class="modal-footer">
@@ -461,18 +504,32 @@
         </div>
     </div>
 
-    <!-- 加载覆盖层 -->
+    <!-- =========================== 加载覆盖层 =========================== -->
+    <!-- 
+        全屏加载遮罩
+        - 默认隐藏，API 调用时显示
+        - 包含旋转动画 (spinner-border) 和加载文字
+    -->
     <div class="loading-overlay" id="loading-overlay">
         <div class="spinner-container">
+            <!-- Bootstrap 旋转加载动画，3rem 大尺寸 -->
             <div class="spinner-border text-light" role="status" style="width: 3rem; height: 3rem;"></div>
             <div class="spinner-message" id="loading-message">正在加载...</div>
         </div>
     </div>
 
-    <!-- 通知容器 -->
+    <!-- =========================== Toast 通知容器 =========================== -->
+    <!-- 
+        通知消息的容器
+        - 固定定位在右上角
+        - JS 动态创建 toast 元素并添加到此容器中
+    -->
     <div class="toast-container"></div>
 
+    <!-- =========================== 脚本引入 =========================== -->
+    <!-- Bootstrap 5 JS (含 Popper.js，用于模态框、Toast 等组件) -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
+    <!-- 自定义前端逻辑脚本 -->
     <script src="static/script.js"></script>
 </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -312,7 +312,7 @@
             <div class="card-body">
                 <div class="row g-3">
                     <div class="col-md-6">
-                        <input type="text" class="form-control" id="save-name" placeholder="存档名称（必填）">
+                        <input type="text" class="form-control" id="save-name" placeholder="存档名称（留空则自动命名为「YYYY-MM-DD - HHMM」（北京时间））">
                     </div>
                     <div class="col-md-6">
                         <div class="d-grid">

--- a/public/index.html
+++ b/public/index.html
@@ -312,7 +312,7 @@
             <div class="card-body">
                 <div class="row g-3">
                     <div class="col-md-6">
-                        <input type="text" class="form-control" id="save-name" placeholder="存档名称（留空则自动命名为「YYYY-MM-DD - HHMM」（北京时间））">
+                        <input type="text" class="form-control" id="save-name" placeholder="存档名称（留空则自动命名为「YYYY-MM-DD - HHMM」）">
                     </div>
                     <div class="col-md-6">
                         <div class="d-grid">

--- a/public/index.html
+++ b/public/index.html
@@ -320,7 +320,7 @@
                     <!-- 存档名称输入（左列） -->
                     <div class="col-md-6">
                         <input type="text" class="form-control" id="save-name" 
-                               placeholder="存档名称（留空则自动命名为「YYYY-MM-DD - HHMM」)">
+                               placeholder="存档名称（留空则自动命名为「YYYY-MM-DD | HHMM」)">
                     </div>
                     <!-- 保存按钮（右列），使用 d-grid 让按钮撑满宽度 -->
                     <div class="col-md-6">

--- a/public/index.html
+++ b/public/index.html
@@ -217,7 +217,7 @@
 <body>
     <div class="container py-4">
         <!-- 修改：将检查更新按钮移到标题前 -->
-        <div class="text-start mb-3"> <!-- 使用 text-start 让按钮靠左，mb-3 增加下方间距 -->
+        <div class="text-start mb-3">
             <button id="check-update-btn" class="btn btn-sm btn-outline-info" title="检查插件更新">
                 <i class="bi bi-cloud-arrow-down-fill"></i> 检查更新
             </button>
@@ -279,8 +279,8 @@
             </div>
         </div>
 
-        <!-- 新增：定时存档设置部分 -->
-        <div id="auto-save-section" class="card mb-4" style="display: none;"> <!-- 初始隐藏，授权后显示 -->
+        <!-- 定时存档设置部分 -->
+        <div id="auto-save-section" class="card mb-4" style="display: none;">
             <div class="card-header">
                 <i class="bi bi-clock-history me-2"></i>定时自动存档设置
             </div>
@@ -289,12 +289,22 @@
                     <input class="form-check-input" type="checkbox" role="switch" id="auto-save-enabled">
                     <label class="form-check-label" for="auto-save-enabled">启用定时自动存档</label>
                 </div>
-                <div class="row g-3" id="auto-save-options" style="display: none;"> <!-- 选项默认隐藏 -->
+                <div class="row g-3" id="auto-save-options" style="display: none;">
+                    <div class="col-12 mb-2">
+                        <label class="form-label">自动存档模式</label>
+                        <div class="btn-group" role="group" id="auto-save-mode-group">
+                            <input type="radio" class="btn-check" name="auto-save-mode" id="auto-save-mode-overwrite" value="overwrite" checked>
+                            <label class="btn btn-outline-primary btn-sm" for="auto-save-mode-overwrite">覆盖已有存档</label>
+                            <input type="radio" class="btn-check" name="auto-save-mode" id="auto-save-mode-create" value="create">
+                            <label class="btn btn-outline-primary btn-sm" for="auto-save-mode-create">创建新存档</label>
+                        </div>
+                        <small class="form-text text-muted d-block mt-1" id="auto-save-mode-hint">覆盖模式：每次自动存档将覆盖指定的已有存档标签。</small>
+                    </div>
                     <div class="col-md-6">
                         <label for="auto-save-interval" class="form-label">存档间隔（分钟）</label>
                         <input type="number" class="form-control" id="auto-save-interval" min="1" value="30">
                     </div>
-                    <div class="col-md-6">
+                    <div class="col-md-6" id="auto-save-target-tag-row">
                         <label for="auto-save-target-tag" class="form-label">覆盖的目标存档标签</label>
                         <input type="text" class="form-control" id="auto-save-target-tag" placeholder="输入要覆盖的存档标签名">
                         <small class="form-text text-muted">必须是已存在的云存档标签名。每次自动存档将覆盖此存档。</small>
@@ -465,4 +475,4 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
     <script src="static/script.js"></script>
 </body>
-</html> 
+</html>

--- a/public/script.js
+++ b/public/script.js
@@ -1,13 +1,61 @@
-// 云存档前端脚本
+/**
+ * ============================================================================
+ * SillyTavern Cloud Saves 插件 - 前端逻辑脚本 (script.js)
+ * ============================================================================
+ * 
+ * 功能概述：
+ *   本脚本负责云存档插件前端的所有交互逻辑，包括：
+ *     - 仓库授权与配置管理
+ *     - 存档的创建、加载、删除、重命名、覆盖
+ *     - 存档列表的搜索、排序和渲染
+ *     - 存档差异对比
+ *     - 定时自动存档设置
+ *     - 临时 Stash 的管理（应用/丢弃）
+ *     - 插件更新检查
+ *     - Toast 通知、加载遮罩、确认对话框等 UI 组件
+ * 
+ * 架构设计：
+ *   - 所有操作通过 apiCall() 统一函数调用后端 API
+ *   - DOM 操作集中在特定函数中，便于维护
+ *   - 使用 Bootstrap 5 的 Modal、Toast 等组件
+ *   - 全局状态通过变量管理（isAuthorized, currentSaves 等）
+ * 
+ * 安全机制：
+ *   - 所有非 GET 请求自动获取 CSRF Token 并添加到请求头
+ *   - GitHub Token 在前端只显示占位符，不暴露实际值
+ * 
+ * 依赖：
+ *   - Bootstrap 5 JS（模态框、Toast）
+ *   - Bootstrap Icons（图标）
+ *   - 后端 API 端点（/api/plugins/cloud-saves/*）
+ * 
+ * ============================================================================
+ */
+
+// DOMContentLoaded 事件：确保页面完全加载后再执行脚本
 document.addEventListener('DOMContentLoaded', function() {
-    // 全局变量
+    
+    // =========================== 全局状态变量 ===========================
+    
+    /** @type {boolean} isAuthorized - 当前是否已完成仓库授权 */
     let isAuthorized = false;
+    
+    /** @type {Array<object>} currentSaves - 当前显示的存档列表数据 */
     let currentSaves = [];
+    
+    /** @type {Function|null} confirmCallback - 确认对话框的确认回调函数 */
     let confirmCallback = null;
+    
+    /** @type {string|null} renameTarget - 当前要重命名的存档标签名 */
     let renameTarget = null;
+    
+    /** @type {boolean} initialConfigHasToken - 初始配置是否包含 token（影响输入框占位符显示） */
     let initialConfigHasToken = false;
 
-    // 获取DOM元素引用
+    // =========================== DOM 元素引用缓存 ===========================
+    // 缓存所有需要频繁访问的 DOM 元素引用，减少 document.getElementById 调用
+
+    // --- 授权区域 ---
     const authSection = document.getElementById('auth-section');
     const authForm = document.getElementById('auth-form');
     const authStatus = document.getElementById('auth-status');
@@ -20,11 +68,13 @@ document.addEventListener('DOMContentLoaded', function() {
     const logoutBtn = document.getElementById('logout-btn');
     const initRepoBtn = document.getElementById('init-repo-btn');
 
+    // --- 创建存档区域 ---
     const createSaveSection = document.getElementById('create-save-section');
     const saveNameInput = document.getElementById('save-name');
     const saveDescriptionInput = document.getElementById('save-description');
     const createSaveBtn = document.getElementById('create-save-btn');
 
+    // --- 存档列表区域 ---
     const savesSection = document.getElementById('saves-section');
     const savesContainer = document.getElementById('saves-container');
     const noSavesMessage = document.getElementById('no-saves-message');
@@ -32,33 +82,39 @@ document.addEventListener('DOMContentLoaded', function() {
     const searchBox = document.getElementById('search-box');
     const sortSelector = document.getElementById('sort-selector');
 
+    // --- Stash 通知区域 ---
     const stashNotification = document.getElementById('stash-notification');
     const applyStashBtn = document.getElementById('apply-stash-btn');
     const discardStashBtn = document.getElementById('discard-stash-btn');
 
+    // --- 状态栏 ---
     const gitStatus = document.getElementById('git-status');
     const changesStatus = document.getElementById('changes-status');
     const changesCount = document.getElementById('changes-count');
     const currentSaveStatus = document.getElementById('current-save-status');
 
+    // --- 加载遮罩 ---
     const loadingOverlay = document.getElementById('loading-overlay');
     const loadingMessage = document.getElementById('loading-message');
 
+    // --- 重命名模态框 ---
     const renameModal = new bootstrap.Modal(document.getElementById('renameModal'));
     const renameTagNameInput = document.getElementById('rename-tag-name');
     const renameNewNameInput = document.getElementById('rename-new-name');
     const renameDescriptionInput = document.getElementById('rename-description');
     const confirmRenameBtn = document.getElementById('confirm-rename-btn');
 
+    // --- 确认对话框模态框 ---
     const confirmModal = new bootstrap.Modal(document.getElementById('confirmModal'));
     const confirmMessageText = document.getElementById('confirm-message');
     const confirmActionBtn = document.getElementById('confirm-action-btn');
 
+    // --- 差异对比模态框 ---
     const diffModal = new bootstrap.Modal(document.getElementById('diffModal'));
     const diffSummary = document.getElementById('diff-summary');
     const diffFiles = document.getElementById('diff-files');
 
-    // 定时存档 UI 元素
+    // --- 定时存档 UI 元素 ---
     const autoSaveSection = document.getElementById('auto-save-section');
     const autoSaveEnabledSwitch = document.getElementById('auto-save-enabled');
     const autoSaveOptionsDiv = document.getElementById('auto-save-options');
@@ -66,16 +122,38 @@ document.addEventListener('DOMContentLoaded', function() {
     const autoSaveTargetTagInput = document.getElementById('auto-save-target-tag');
     const saveAutoSaveSettingsBtn = document.getElementById('save-auto-save-settings-btn');
 
-    // 自动存档模式切换元素
+    // --- 自动存档模式切换元素 ---
     const autoSaveModeOverwriteRadio = document.getElementById('auto-save-mode-overwrite');
     const autoSaveModeCreateRadio = document.getElementById('auto-save-mode-create');
     const autoSaveModeHint = document.getElementById('auto-save-mode-hint');
     const autoSaveTargetTagRow = document.getElementById('auto-save-target-tag-row');
 
-    // 检查更新按钮
+    // --- 检查更新按钮 ---
     const checkUpdateBtn = document.getElementById('check-update-btn');
 
-    // API调用工具函数
+    // =========================== API 调用工具函数 ===========================
+
+    /**
+     * apiCall - 统一的 API 调用封装函数
+     * 
+     * 封装了所有与后端通信的细节，包括：
+     *   - CSRF Token 的自动获取和注入
+     *   - JSON 请求/响应的序列化/反序列化
+     *   - HTTP 错误的统一处理
+     *   - 非 JSON 响应的检测（如认证错误返回 HTML）
+     * 
+     * CSRF 保护机制：
+     *   SillyTavern 使用 CSRF Token 来防止跨站请求伪造攻击。
+     *   所有非 GET 请求都必须携带有效的 CSRF Token。
+     *   获取方式：先请求 /csrf-token 端点获取 token，
+     *   然后将其添加到请求头的 X-CSRF-Token 字段中。
+     * 
+     * @param {string} endpoint - API 端点路径（不包含基础 URL）
+     * @param {string} method - HTTP 方法 (GET|POST|PUT|DELETE)，默认为 'GET'
+     * @param {object|null} data - 要发送的请求体数据（仅用于 POST/PUT）
+     * @returns {Promise<object>} - 解析后的 JSON 响应
+     * @throws {Error} - 当请求失败或返回错误时抛出
+     */
     async function apiCall(endpoint, method = 'GET', data = null) {
         const options = {
             method: method,
@@ -84,9 +162,10 @@ document.addEventListener('DOMContentLoaded', function() {
             }
         };
 
-        // 对于非GET请求，先获取CSRF令牌
+        // 对于非 GET/HEAD 请求，获取 CSRF Token 并添加到请求头
         if (method !== 'GET' && method !== 'HEAD') {
             try {
+                // 向 SillyTavern 主程序请求 CSRF Token
                 const csrfResponse = await fetch('/csrf-token');
                 if (!csrfResponse.ok) {
                     throw new Error(`获取CSRF令牌失败: ${csrfResponse.statusText}`);
@@ -95,6 +174,7 @@ document.addEventListener('DOMContentLoaded', function() {
                 if (!csrfData || !csrfData.token) {
                     throw new Error('无效的CSRF令牌响应');
                 }
+                // 将 token 添加到请求头
                 options.headers['X-CSRF-Token'] = csrfData.token;
             } catch (csrfError) {
                 console.error('无法获取或设置CSRF令牌:', csrfError);
@@ -103,22 +183,28 @@ document.addEventListener('DOMContentLoaded', function() {
             }
         }
 
+        // 将 data 对象序列化为 JSON 字符串作为请求体
         if (data && (method === 'POST' || method === 'PUT')) {
             options.body = JSON.stringify(data);
         }
 
         try {
+            // 发送请求（基础路径 /api/plugins/cloud-saves/ 由 SillyTavern 路由提供）
             const response = await fetch(`/api/plugins/cloud-saves/${endpoint}`, options);
+            
+            // 检测非 JSON 响应（通常是认证错误或服务器错误返回的 HTML 页面）
             if (!response.ok && response.headers.get('content-type')?.includes('text/html')) {
-                 if (response.status === 403) {
-                     throw new Error('认证或权限错误 (403 Forbidden)。可能是CSRF令牌问题或GitHub Token权限不足。');
-                 } else {
+                if (response.status === 403) {
+                    throw new Error('认证或权限错误 (403 Forbidden)。可能是CSRF令牌问题或GitHub Token权限不足。');
+                } else {
                     throw new Error(`请求失败，服务器返回了非JSON响应 (状态码: ${response.status})`);
-                 }
+                }
             }
             
+            // 解析 JSON 响应
             const result = await response.json();
             
+            // HTTP 状态码非 2xx 时视为错误
             if (!response.ok) {
                 throw new Error(result.message || `请求失败，状态码: ${response.status}`); 
             }
@@ -126,32 +212,65 @@ document.addEventListener('DOMContentLoaded', function() {
             return result;
         } catch (error) {
             console.error(`API调用失败 (${endpoint}):`, error);
+            // 避免重复显示 CSRF 错误
             if (!error.message.includes('安全令牌失败')) {
-                 showToast('错误', `操作失败: ${error.message}`, 'error');
+                showToast('错误', `操作失败: ${error.message}`, 'error');
             }
             throw error;
         }
     }
 
-    // 加载/显示函数
+    // =========================== UI 工具函数 ===========================
+
+    /**
+     * showLoading - 显示加载遮罩层
+     * 
+     * 在耗时操作期间覆盖整个界面，防止用户误操作，
+     * 同时提供加载状态的可视化反馈。
+     * 
+     * @param {string} message - 加载提示文字，默认为 "正在加载..."
+     */
     function showLoading(message = '正在加载...') {
         loadingMessage.textContent = message;
-        loadingOverlay.style.display = 'flex';
+        loadingOverlay.style.display = 'flex';  // 使用 flex 居中加载动画
     }
 
+    /**
+     * hideLoading - 隐藏加载遮罩层
+     */
     function hideLoading() {
         loadingOverlay.style.display = 'none';
     }
 
+    /**
+     * showToast - 显示 Toast 通知消息
+     * 
+     * Toast 是轻量级的非阻塞通知，自动在数秒后消失。
+     * 位于页面右上角，不同类型的通知有不同的左边框颜色：
+     *   - success: 绿色边框
+     *   - error/danger: 红色边框
+     *   - warning: 黄色边框
+     *   - info: 主色边框
+     * 
+     * 工作原理：
+     *   动态创建 DOM 元素，添加到 toast-container 中，
+     *   5 秒后自动淡出并移除。
+     * 
+     * @param {string} title - 通知标题
+     * @param {string} message - 通知内容
+     * @param {string} type - 通知类型 (success|error|danger|warning|info)
+     */
     function showToast(title, message, type = 'info') {
         const toastContainer = document.querySelector('.toast-container');
         
+        // 创建 toast 元素
         const toast = document.createElement('div');
         toast.classList.add('toast', 'show');
         toast.setAttribute('role', 'alert');
         toast.setAttribute('aria-live', 'assertive');
         toast.setAttribute('aria-atomic', 'true');
         
+        // 根据类型设置不同的左边框颜色
         if (type === 'success') {
             toast.style.borderLeft = '4px solid var(--bs-success)';
         } else if (type === 'error' || type === 'danger') {
@@ -162,6 +281,7 @@ document.addEventListener('DOMContentLoaded', function() {
             toast.style.borderLeft = '4px solid var(--bs-primary)';
         }
         
+        // 设置 toast 内部 HTML 结构
         toast.innerHTML = `
             <div class="toast-header">
                 <strong class="me-auto">${title}</strong>
@@ -172,13 +292,15 @@ document.addEventListener('DOMContentLoaded', function() {
         
         toastContainer.appendChild(toast);
         
+        // 5 秒后自动移除
         setTimeout(() => {
             toast.classList.remove('show');
             setTimeout(() => {
                 toast.remove();
-            }, 300);
+            }, 300);  // 等待淡出动画完成（300ms）
         }, 5000);
         
+        // 关闭按钮点击事件
         toast.querySelector('.btn-close').addEventListener('click', () => {
             toast.classList.remove('show');
             setTimeout(() => {
@@ -187,16 +309,32 @@ document.addEventListener('DOMContentLoaded', function() {
         });
     }
 
-    // 初始化
+    // =========================== 初始化函数 ===========================
+
+    /**
+     * init - 页面初始化函数
+     * 
+     * 页面加载后立即执行，完成以下任务：
+     *   1. 从后端读取当前配置
+     *   2. 用配置填充表单字段
+     *   3. 处理 Token 输入框的占位符显示
+     *   4. 设置自动存档相关的 UI 状态
+     *   5. 如果已授权，刷新状态并加载存档列表
+     * 
+     * 错误处理：
+     *   如果读取配置失败（如后端未启动），设置默认占位符状态
+     */
     async function init() {
         try {
             const config = await apiCall('config');
 
+            // 填充表单字段
             if (config.repo_url) repoUrlInput.value = config.repo_url;
             if (config.display_name) displayNameInput.value = config.display_name;
             if (config.branch) branchInput.value = config.branch;
             
-            // Token Input Handling
+            // Token 输入框处理逻辑：
+            // 如果后端已保存 token，显示"已保存"占位符，不显示实际值
             initialConfigHasToken = config.has_github_token;
             if (initialConfigHasToken) {
                 githubTokenInput.placeholder = "访问令牌已保存";
@@ -206,42 +344,62 @@ document.addEventListener('DOMContentLoaded', function() {
                 githubTokenInput.value = "";
             }
             
+            // 设置自动存档开关和选项
             autoSaveEnabledSwitch.checked = config.autoSaveEnabled || false;
             autoSaveIntervalInput.value = config.autoSaveInterval || 30;
             autoSaveTargetTagInput.value = config.autoSaveTargetTag || '';
 
-            // 设置自动存档模式
+            // 设置自动存档模式（覆盖 vs 创建）
             const savedMode = config.autoSaveMode || 'overwrite';
             if (savedMode === 'create') {
                 autoSaveModeCreateRadio.checked = true;
                 autoSaveModeOverwriteRadio.checked = false;
-                autoSaveTargetTagRow.style.display = 'none';
+                autoSaveTargetTagRow.style.display = 'none';      // 创建模式不需要目标标签
                 autoSaveModeHint.textContent = '创建模式：每次自动存档将创建新存档（命名格式：YYYY-MM-DD - HHMM (Auto Save)），使用浏览器时区。';
             } else {
                 autoSaveModeOverwriteRadio.checked = true;
                 autoSaveModeCreateRadio.checked = false;
-                autoSaveTargetTagRow.style.display = '';
+                autoSaveTargetTagRow.style.display = '';           // 覆盖模式需要目标标签
                 autoSaveModeHint.textContent = '覆盖模式：每次自动存档将覆盖指定的已有存档标签。';
             }
 
+            // 根据启用状态显示/隐藏自动存档选项
             autoSaveOptionsDiv.style.display = autoSaveEnabledSwitch.checked ? 'flex' : 'none';
             
             isAuthorized = config.is_authorized;
             
+            // 更新 UI 以反映授权状态
             updateAuthUI(isAuthorized);
             
+            // 如果已授权，加载完整数据
             if (isAuthorized) {
                 await refreshStatus();
                 await loadSavesList();
             }
         } catch (error) {
+            // 初始化失败时设置默认状态
             githubTokenInput.placeholder = "例如: ghp_xxxxxxxxxxxx";
             githubTokenInput.value = "";
             initialConfigHasToken = false;
         }
     }
 
-    // 更新授权UI
+    // =========================== UI 状态更新函数 ===========================
+
+    /**
+     * updateAuthUI - 根据授权状态更新 UI 显示
+     * 
+     * 授权成功时：
+     *   - 显示成功提示
+     *   - 显示断开连接按钮
+     *   - 显示创建存档、存档列表、自动存档区域
+     * 
+     * 未授权时：
+     *   - 隐藏上述所有区域
+     *   - 重置 Token 输入框占位符
+     * 
+     * @param {boolean} authorized - 是否已授权
+     */
     function updateAuthUI(authorized) {
         isAuthorized = authorized;
 
@@ -279,7 +437,15 @@ document.addEventListener('DOMContentLoaded', function() {
         }
     }
 
-    // 刷新Git状态
+    /**
+     * refreshStatus - 刷新 Git 仓库状态并更新状态栏
+     * 
+     * 从后端获取当前仓库状态，更新：
+     *   - Git 仓库是否就绪
+     *   - 未保存更改数量
+     *   - 当前加载的存档名称
+     *   - 临时 Stash 通知条的显示/隐藏
+     */
     async function refreshStatus() {
         try {
             const statusResult = await apiCall('status');
@@ -287,12 +453,14 @@ document.addEventListener('DOMContentLoaded', function() {
             if (statusResult.success && statusResult.status) {
                 const status = statusResult.status;
                 
+                // 更新 Git 仓库状态指示器
                 if (status.initialized) {
                     gitStatus.innerHTML = `<i class="bi bi-check-circle-fill text-success me-2"></i>Git仓库就绪`;
                 } else {
                     gitStatus.innerHTML = `<i class="bi bi-circle-fill text-secondary me-2"></i>Git仓库未初始化`;
                 }
                 
+                // 更新未保存更改数量
                 if (status.changes && status.changes.length > 0) {
                     changesCount.textContent = status.changes.length;
                     changesStatus.style.display = 'inline';
@@ -300,7 +468,9 @@ document.addEventListener('DOMContentLoaded', function() {
                     changesStatus.style.display = 'none';
                 }
                 
+                // 更新当前存档信息
                 if (status.currentSave) {
+                    // 从标签名中提取存档名称（解码 base64url）
                     const saveNameMatch = status.currentSave.tag.match(/^save_\d+_(.+)$/);
                     const saveName = saveNameMatch ? saveNameMatch[1] : status.currentSave.tag;
                     currentSaveStatus.innerHTML = `当前存档: <strong>${saveName}</strong>`;
@@ -308,6 +478,7 @@ document.addEventListener('DOMContentLoaded', function() {
                     currentSaveStatus.textContent = '未加载任何存档';
                 }
                 
+                // 显示/隐藏 Stash 通知条
                 if (status.tempStash && status.tempStash.exists) {
                     stashNotification.style.display = 'block';
                 } else {
@@ -320,7 +491,18 @@ document.addEventListener('DOMContentLoaded', function() {
         }
     }
 
-    // 加载存档列表
+    // =========================== 存档列表加载与渲染 ===========================
+
+    /**
+     * loadSavesList - 从后端加载存档列表并渲染到页面
+     * 
+     * 流程：
+     *   1. 显示加载遮罩
+     *   2. 调用 API 获取存档列表
+     *   3. 更新 currentSaves 全局状态
+     *   4. 调用 renderSavesList 渲染 HTML
+     *   5. 隐藏加载遮罩
+     */
     async function loadSavesList() {
         try {
             showLoading('正在获取存档列表...');
@@ -329,7 +511,6 @@ document.addEventListener('DOMContentLoaded', function() {
             
             if (result.success && result.saves) {
                 currentSaves = result.saves;
-                
                 renderSavesList(currentSaves);
             } else {
                 throw new Error(result.message || '获取存档列表失败');
@@ -343,23 +524,48 @@ document.addEventListener('DOMContentLoaded', function() {
         }
     }
 
-    // 渲染存档列表
+    /**
+     * renderSavesList - 将存档数据渲染为 HTML 卡片列表
+     * 
+     * 每个存档卡片包含：
+     *   - 存档名称、创建时间、更新时间
+     *   - 操作人信息
+     *   - 描述文本
+     *   - 标签名和复制按钮
+     *   - 操作按钮组：重命名、加载、覆盖、差异、删除
+     * 
+     * 特殊标记：
+     *   - 如果存档是当前加载的，右上角显示"当前存档"徽章
+     * 
+     * 渲染流程：
+     *   1. 清空容器
+     *   2. 检查是否为空（显示空状态占位）
+     *   3. 异步获取当前加载的存档信息
+     *   4. 遍历存档数据创建卡片 DOM
+     *   5. 为当前存档添加角标
+     *   6. 注册所有按钮的事件处理器
+     * 
+     * @param {Array<object>} saves - 存档对象数组
+     */
     function renderSavesList(saves) {
+        // 清空容器（保留 no-saves-message 用于空状态）
         while (savesContainer.firstChild) {
             savesContainer.removeChild(savesContainer.firstChild);
         }
         
+        // 空列表：显示空状态提示
         if (saves.length === 0) {
             savesContainer.appendChild(noSavesMessage);
             return;
         }
         
+        // 异步获取当前加载的存档标签名
         let currentLoadedSave = null;
-        
         apiCall('config').then(config => {
             if (config.current_save && config.current_save.tag) {
                 currentLoadedSave = config.current_save.tag;
                 
+                // 如果当前存档卡片已渲染，添加角标
                 const currentSaveCard = document.querySelector(`.save-card[data-tag="${currentLoadedSave}"]`);
                 if (currentSaveCard) {
                     const badge = document.createElement('div');
@@ -370,24 +576,28 @@ document.addEventListener('DOMContentLoaded', function() {
             }
         });
         
+        // 遍历每个存档，创建对应的卡片 DOM
         saves.forEach(save => {
+            // 创建卡片容器
             const saveCard = document.createElement('div');
             saveCard.classList.add('card', 'save-card', 'mb-3');
-            saveCard.dataset.tag = save.tag;
+            saveCard.dataset.tag = save.tag;  // 将标签名存入 dataset 便于查找
             
-            const saveDate = new Date(save.timestamp);
-            const formattedDate = saveDate.toLocaleString();
-            
+            // 格式化时间戳为本地可读格式
             const createdAtDate = new Date(save.createdAt);
             const updatedAtDate = new Date(save.updatedAt);
             const formattedCreatedAt = createdAtDate.toLocaleString();
             const formattedUpdatedAt = updatedAtDate.toLocaleString();
+            
+            // 获取描述和创建者信息
             const descriptionText = save.description || '无描述';
             const creatorName = save.creator || '未知';
             
+            // 构建卡片 HTML 结构
             saveCard.innerHTML = `
                 <div class="card-body">
                     <div class="d-flex justify-content-between align-items-start">
+                        <!-- 左侧：存档信息 -->
                         <div style="flex-grow: 1; margin-right: 15px;">
                             <h5 class="card-title mb-1">${save.name}</h5>
                             <div class="save-timestamp mb-1">
@@ -395,6 +605,7 @@ document.addEventListener('DOMContentLoaded', function() {
                             </div>
                             <div class="save-creator mb-2">操作人: ${creatorName}</div>
                             <div class="save-description">${descriptionText}</div>
+                            <!-- 标签名和复制按钮 -->
                             <div class="save-tag-info mt-2">
                                 <small class="text-muted">标签名: <code class="user-select-all">${save.tag}</code></small>
                                 <button class="btn btn-sm btn-outline-secondary copy-tag-btn ms-1" data-tag="${save.tag}" title="复制标签名">
@@ -402,19 +613,28 @@ document.addEventListener('DOMContentLoaded', function() {
                                 </button>
                             </div>
                         </div>
+                        <!-- 右侧：操作按钮组 -->
                         <div class="action-buttons flex-shrink-0">
-                            <button class="btn btn-sm btn-primary rename-save-btn" data-tag="${save.tag}" data-name="${save.name}" data-description="${descriptionText}" title="重命名此存档">
+                            <!-- 重命名按钮 (bi-pencil) -->
+                            <button class="btn btn-sm btn-primary rename-save-btn" data-tag="${save.tag}" 
+                                    data-name="${save.name}" data-description="${descriptionText}" title="重命名此存档">
                                 <i class="bi bi-pencil"></i>
                             </button>
+                            <!-- 加载按钮 (bi-cloud-download) -->
                             <button class="btn btn-sm btn-success load-save-btn" data-tag="${save.tag}" title="加载此存档">
                                 <i class="bi bi-cloud-download"></i>
                             </button>
-                            <button class="btn btn-sm btn-warning overwrite-save-btn" data-tag="${save.tag}" data-name="${save.name}" title="用当前本地数据覆盖此云存档">
+                            <!-- 覆盖按钮 (bi-upload) -->
+                            <button class="btn btn-sm btn-warning overwrite-save-btn" data-tag="${save.tag}" 
+                                    data-name="${save.name}" title="用当前本地数据覆盖此云存档">
                                 <i class="bi bi-upload"></i>
                             </button>
-                            <button class="btn btn-sm btn-outline-info diff-save-btn" data-tag="${save.tag}" data-name="${save.name}" title="比较差异">
+                            <!-- 差异对比按钮 (bi-file-diff) -->
+                            <button class="btn btn-sm btn-outline-info diff-save-btn" data-tag="${save.tag}" 
+                                    data-name="${save.name}" title="比较差异">
                                 <i class="bi bi-file-diff"></i>
                             </button>
+                            <!-- 删除按钮 (bi-trash) -->
                             <button class="btn btn-sm btn-danger delete-save-btn" data-tag="${save.tag}" title="删除此存档">
                                 <i class="bi bi-trash"></i>
                             </button>
@@ -423,6 +643,7 @@ document.addEventListener('DOMContentLoaded', function() {
                 </div>
             `;
             
+            // 如果是当前加载的存档，立即添加角标
             if (save.tag === currentLoadedSave) {
                 const badge = document.createElement('div');
                 badge.classList.add('save-current-badge');
@@ -433,14 +654,32 @@ document.addEventListener('DOMContentLoaded', function() {
             savesContainer.appendChild(saveCard);
         });
         
+        // 注册所有按钮的事件处理器
         registerSaveCardEvents();
     }
     
-    // 注册存档卡片按钮事件
+    /**
+     * registerSaveCardEvents - 为动态渲染的存档卡片按钮绑定事件
+     * 
+     * 由于存档卡片是动态创建的（而非在 HTML 中写死），
+     * 需要使用事件委托或动态绑定方式来注册事件。
+     * 这里采用 querySelectorAll + forEach 的方式为每个按钮单独绑定。
+     * 
+     * 注册的按钮类型：
+     *   1. .load-save-btn         - 加载存档
+     *   2. .rename-save-btn       - 打开重命名模态框
+     *   3. .overwrite-save-btn    - 覆盖存档
+     *   4. .delete-save-btn       - 删除存档
+     *   5. .diff-save-btn         - 查看差异
+     *   6. .copy-tag-btn          - 复制标签名到剪贴板
+     */
     function registerSaveCardEvents() {
+        
+        // --- 加载存档按钮 ---
         document.querySelectorAll('.load-save-btn').forEach(btn => {
             btn.addEventListener('click', async function() {
                 const tagName = this.dataset.tag;
+                // 使用确认对话框，防止误操作
                 showConfirmDialog(
                     `确认加载存档`,
                     `您确定要加载此存档吗？所有当前未保存的更改将被暂存。`,
@@ -451,16 +690,18 @@ document.addEventListener('DOMContentLoaded', function() {
             });
         });
         
+        // --- 重命名存档按钮 ---
         document.querySelectorAll('.rename-save-btn').forEach(btn => {
             btn.addEventListener('click', function() {
-                renameTarget = this.dataset.tag;
-                renameTagNameInput.value = renameTarget;
+                renameTarget = this.dataset.tag;          // 记录要重命名的标签
+                renameTagNameInput.value = renameTarget;   // 填充隐藏字段
                 renameNewNameInput.value = this.dataset.name || '';
                 renameDescriptionInput.value = this.dataset.description || '';
-                renameModal.show();
+                renameModal.show();                       // 显示重命名模态框
             });
         });
         
+        // --- 覆盖存档按钮（危险操作，需要确认） ---
         document.querySelectorAll('.overwrite-save-btn').forEach(btn => {
             btn.addEventListener('click', function() {
                 const tagName = this.dataset.tag;
@@ -476,6 +717,7 @@ document.addEventListener('DOMContentLoaded', function() {
             });
         });
         
+        // --- 删除存档按钮 ---
         document.querySelectorAll('.delete-save-btn').forEach(btn => {
             btn.addEventListener('click', function() {
                 const tagName = this.dataset.tag;
@@ -489,23 +731,22 @@ document.addEventListener('DOMContentLoaded', function() {
             });
         });
         
+        // --- 差异对比按钮 ---
         document.querySelectorAll('.diff-save-btn').forEach(btn => {
             btn.addEventListener('click', async function() {
                 const tagName = this.dataset.tag;
                 const saveName = this.dataset.name;
-                console.log('Comparing save:', tagName, 'Name from dataset:', saveName);
-                if (!saveName) {
-                    console.error('Could not retrieve save name from button dataset!');
-                }
                 
                 try {
                     showLoading('正在加载差异...');
                     
+                    // 对比存档标签和当前 HEAD 之间的差异
                     const tagRef1 = encodeURIComponent(tagName);
                     const tagRef2 = 'HEAD';
                     const result = await apiCall(`saves/diff?tag1=${tagRef1}&tag2=${tagRef2}`);
                     
                     if (result.success) {
+                        // 设置模态框标题
                         const diffModalLabel = document.getElementById('diffModalLabel');
                         diffModalLabel.textContent = `存档 "${saveName || tagName}" 与当前状态的差异`;
                         
@@ -514,11 +755,14 @@ document.addEventListener('DOMContentLoaded', function() {
                         
                         diffFiles.innerHTML = '';
                         if (result.changedFiles && result.changedFiles.length > 0) {
-                           const fileList = document.createElement('ul');
+                            // 构建变更文件列表
+                            const fileList = document.createElement('ul');
                             fileList.classList.add('list-unstyled'); 
                             result.changedFiles.forEach(file => {
                                 const li = document.createElement('li');
                                 li.classList.add('mb-1');
+                                
+                                // 根据变更状态设置图标和颜色
                                 let statusText = '';
                                 let statusClass = '';
                                 let statusIcon = ''; 
@@ -535,6 +779,7 @@ document.addEventListener('DOMContentLoaded', function() {
                             });
                             diffFiles.appendChild(fileList);
                         } else {
+                            // 无变更
                             diffFiles.innerHTML = '<p class="text-center text-secondary mt-3">此存档与当前状态没有文件差异。</p>';
                         }
                         
@@ -551,14 +796,18 @@ document.addEventListener('DOMContentLoaded', function() {
             });
         });
 
+        // --- 复制标签名按钮 ---
         document.querySelectorAll('.copy-tag-btn').forEach(btn => {
             btn.addEventListener('click', function() {
                 const tagName = this.dataset.tag;
+                // 使用 Clipboard API 复制文本
                 navigator.clipboard.writeText(tagName).then(() => {
+                    // 复制成功后图标短暂变为对勾
                     const icon = this.querySelector('i');
                     const originalIconClass = icon.className;
                     icon.className = 'bi bi-check-lg text-success'; 
                     showToast('提示', '标签名已复制到剪贴板', 'info');
+                    // 1.5 秒后恢复原图标
                     setTimeout(() => {
                         icon.className = originalIconClass;
                     }, 1500);
@@ -570,7 +819,15 @@ document.addEventListener('DOMContentLoaded', function() {
         });
     }
 
-    // 加载存档
+    // =========================== 存档操作函数 ===========================
+
+    /**
+     * loadSave - 加载指定的存档到当前工作区
+     * 
+     * 加载后会自动刷新状态，并为当前存档添加高亮角标。
+     * 
+     * @param {string} tagName - 要加载的存档标签名
+     */
     async function loadSave(tagName) {
         try {
             showLoading('正在加载存档...');
@@ -580,6 +837,7 @@ document.addEventListener('DOMContentLoaded', function() {
             if (result.success) {
                 showToast('成功', '存档加载成功', 'success');
                 await refreshStatus();
+                // 高亮当前加载的存档卡片
                 highlightCurrentSave(tagName);
             } else {
                 throw new Error(result.message || '加载存档失败');
@@ -593,8 +851,17 @@ document.addEventListener('DOMContentLoaded', function() {
         }
     }
 
+    /**
+     * highlightCurrentSave - 高亮显示当前加载的存档
+     * 
+     * 移除所有旧的"当前存档"角标，然后在指定标签的卡片上添加新角标。
+     * 
+     * @param {string} tagName - 当前存档的标签名
+     */
     function highlightCurrentSave(tagName) {
+        // 移除所有已存在的角标
         document.querySelectorAll('.save-current-badge').forEach(badge => badge.remove());
+        // 在对应卡片上添加角标
         const saveCard = document.querySelector(`.save-card[data-tag="${tagName}"]`);
         if (saveCard) {
             const badge = document.createElement('div');
@@ -604,7 +871,14 @@ document.addEventListener('DOMContentLoaded', function() {
         }
     }
 
-    // 删除存档
+    /**
+     * deleteSave - 删除指定的存档
+     * 
+     * 删除成功后从本地列表移除并重新渲染。
+     * 如果删除的是远程存档但删除失败（网络问题），会显示警告。
+     * 
+     * @param {string} tagName - 要删除的存档标签名
+     */
     async function deleteSave(tagName) {
         try {
             showLoading('正在删除存档...');
@@ -613,11 +887,13 @@ document.addEventListener('DOMContentLoaded', function() {
             
             if (result.success) {
                 if (result.warning) {
+                    // 远程删除有问题但本地已删除
                     showToast('警告', result.message, 'warning');
                 } else {
                     showToast('成功', '存档已删除', 'success');
                 }
                 
+                // 从本地列表移除并重新渲染
                 currentSaves = currentSaves.filter(save => save.tag !== tagName);
                 renderSavesList(currentSaves);
                 
@@ -634,11 +910,19 @@ document.addEventListener('DOMContentLoaded', function() {
         }
     }
 
-    // 创建存档
+    /**
+     * createSave - 创建一个新的云端存档
+     * 
+     * 存档名称如果为空，自动生成格式：YYYY-MM-DD - HHMM
+     * 创建成功后清空输入框并刷新列表。
+     * 
+     * @param {string} name - 存档名称
+     * @param {string} description - 存档描述
+     */
     async function createSave(name, description) {
         try {
+            // 处理空名称：自动生成
             let finalName = name ? name.trim() : '';
-            
             if (finalName === '') {
                 const now = new Date();
                 const year = now.getFullYear();
@@ -659,9 +943,11 @@ document.addEventListener('DOMContentLoaded', function() {
             if (result.success) {
                 showToast('成功', '存档创建成功', 'success');
                 
+                // 清空输入框
                 saveNameInput.value = '';
                 saveDescriptionInput.value = '';
                 
+                // 刷新列表和状态
                 await loadSavesList();
                 await refreshStatus();
             } else {
@@ -676,7 +962,13 @@ document.addEventListener('DOMContentLoaded', function() {
         }
     }
 
-    // 重命名存档
+    /**
+     * renameSave - 重命名存档（通过重命名模态框触发）
+     * 
+     * @param {string} oldTagName - 旧的存档标签名
+     * @param {string} newName - 新的存档名称
+     * @param {string} description - 新的存档描述
+     */
     async function renameSave(oldTagName, newName, description) {
         try {
             if (!newName || newName.trim() === '') {
@@ -693,7 +985,6 @@ document.addEventListener('DOMContentLoaded', function() {
             
             if (result.success) {
                 showToast('成功', '存档重命名成功', 'success');
-                
                 await loadSavesList();
             } else {
                 throw new Error(result.message || '重命名存档失败');
@@ -707,11 +998,22 @@ document.addEventListener('DOMContentLoaded', function() {
         }
     }
 
+    // =========================== 授权与登出 ===========================
+
+    /**
+     * authorize - 执行仓库授权流程
+     * 
+     * 向后端发送授权请求，验证 GitHub 仓库的连接和权限。
+     * 
+     * @param {string} repoUrl - GitHub 仓库 URL
+     * @param {string} displayName - 用户显示名称
+     * @param {string} branch - 目标分支名
+     */
     async function authorize(repoUrl, displayName, branch) {
         try {
             if (!repoUrl) {
-                 showToast('错误', '仓库 URL 不能为空', 'error');
-                 return;
+                showToast('错误', '仓库 URL 不能为空', 'error');
+                return;
             }
 
             showLoading('正在授权并连接仓库...');
@@ -735,6 +1037,7 @@ document.addEventListener('DOMContentLoaded', function() {
             hideLoading();
             console.error('授权失败:', error);
 
+            // 在授权状态区域显示错误信息
             authStatus.innerHTML = `<i class="bi bi-x-circle-fill text-danger me-2"></i>授权失败: ${error.message}`;
             authStatus.classList.remove('alert-success');
             authStatus.classList.add('alert-danger');
@@ -744,10 +1047,16 @@ document.addEventListener('DOMContentLoaded', function() {
         }
     }
 
+    /**
+     * logout - 断开仓库连接
+     * 
+     * 清除后端 token 和授权状态，恢复 UI 到未授权状态。
+     */
     async function logout() {
         try {
             showLoading('正在断开连接...');
 
+            // 清除后端配置中的 token 和授权状态
             await apiCall('config', 'POST', {
                 github_token: '',
                 is_authorized: false
@@ -766,6 +1075,14 @@ document.addEventListener('DOMContentLoaded', function() {
         }
     }
 
+    // =========================== Stash 操作 ===========================
+
+    /**
+     * applyStash - 应用（恢复）临时 stash 到工作区
+     * 
+     * 加载存档时如果用户有未保存的更改，会自动 stash。
+     * 此函数将这些更改恢复到工作区。
+     */
     async function applyStash() {
         try {
             showLoading('正在恢复临时更改...');
@@ -775,7 +1092,6 @@ document.addEventListener('DOMContentLoaded', function() {
             if (result.success) {
                 stashNotification.style.display = 'none';
                 showToast('成功', '临时更改已恢复', 'success');
-                
                 await refreshStatus();
             } else {
                 throw new Error(result.message || '恢复临时更改失败');
@@ -789,6 +1105,9 @@ document.addEventListener('DOMContentLoaded', function() {
         }
     }
 
+    /**
+     * discardStash - 丢弃临时 stash（不恢复更改）
+     */
     async function discardStash() {
         try {
             showLoading('正在丢弃临时更改...');
@@ -798,7 +1117,6 @@ document.addEventListener('DOMContentLoaded', function() {
             if (result.success) {
                 stashNotification.style.display = 'none';
                 showToast('成功', '临时更改已丢弃', 'success');
-                
                 await refreshStatus();
             } else {
                 throw new Error(result.message || '丢弃临时更改失败');
@@ -812,6 +1130,16 @@ document.addEventListener('DOMContentLoaded', function() {
         }
     }
 
+    // =========================== 覆盖存档 ===========================
+
+    /**
+     * overwriteSave - 用当前本地数据覆盖指定的云存档
+     * 
+     * 这是一个危险操作，会永久替换云端存档的内容。
+     * 调用前需要通过确认对话框获得用户确认。
+     * 
+     * @param {string} tagName - 要覆盖的存档标签名
+     */
     async function overwriteSave(tagName) {
         try {
             showLoading('正在覆盖存档...');
@@ -820,8 +1148,8 @@ document.addEventListener('DOMContentLoaded', function() {
             
             if (result.success) {
                 showToast('成功', '存档已成功覆盖', 'success');
-                await loadSavesList(); 
-                await refreshStatus();
+                await loadSavesList();   // 刷新存档列表
+                await refreshStatus();   // 刷新状态
             } else {
                 throw new Error(result.message || '覆盖存档失败');
             }
@@ -834,12 +1162,27 @@ document.addEventListener('DOMContentLoaded', function() {
         }
     }
 
+    // =========================== 搜索与排序 ===========================
+
+    /**
+     * filterAndSortSaves - 根据搜索词和排序方式过滤并排序存档列表
+     * 
+     * 搜索：在存档名称和描述中进行不区分大小写的模糊匹配
+     * 排序选项：
+     *   - updated-desc: 按更新时间降序（最新在前）
+     *   - updated-asc: 按更新时间升序（最旧在前）
+     *   - name-asc: 名称 A-Z
+     *   - name-desc: 名称 Z-A
+     * 
+     * 过滤和排序后重新渲染存档列表。
+     */
     function filterAndSortSaves() {
         if (!currentSaves || currentSaves.length === 0) return;
         
         const searchTerm = searchBox.value.toLowerCase();
         const sortMethod = sortSelector.value;
         
+        // 过滤：搜索词匹配名称或描述
         let filteredSaves = currentSaves;
         if (searchTerm) {
             filteredSaves = currentSaves.filter(save => 
@@ -848,6 +1191,7 @@ document.addEventListener('DOMContentLoaded', function() {
             );
         }
         
+        // 排序
         filteredSaves.sort((a, b) => {
             switch (sortMethod) {
                 case 'updated-desc':
@@ -866,6 +1210,16 @@ document.addEventListener('DOMContentLoaded', function() {
         renderSavesList(filteredSaves);
     }
 
+    // =========================== 配置保存 ===========================
+
+    /**
+     * saveConfiguration - 保存基本配置（仓库 URL、Token、显示名称、分支）
+     * 
+     * 注意：此函数只保存配置信息，不进行授权验证。
+     * 授权验证由 authorize() 函数完成。
+     * 
+     * @returns {Promise<boolean>} - 是否保存成功
+     */
     async function saveConfiguration() {
         const repoUrl = repoUrlInput.value.trim();
         const token = githubTokenInput.value.trim();
@@ -885,6 +1239,7 @@ document.addEventListener('DOMContentLoaded', function() {
                 showToast('成功', '配置已保存', 'success');
                 branchInput.value = branch;
 
+                // 更新 token 输入框状态
                 if (token) {
                     initialConfigHasToken = true;
                     githubTokenInput.placeholder = "访问令牌已保存";
@@ -910,13 +1265,25 @@ document.addEventListener('DOMContentLoaded', function() {
         }
     }
 
+    /**
+     * saveAutoSaveConfiguration - 保存定时自动存档设置
+     * 
+     * 包括：启用状态、间隔时间、目标标签、存档模式、时区偏移
+     * 
+     * 验证逻辑：
+     *   - 覆盖模式必须指定目标标签
+     * 
+     * @returns {Promise<boolean>} - 是否保存成功
+     */
     async function saveAutoSaveConfiguration() {
         const enabled = autoSaveEnabledSwitch.checked;
         const interval = parseInt(autoSaveIntervalInput.value, 10) || 30;
         const targetTag = autoSaveTargetTagInput.value.trim();
         const mode = autoSaveModeCreateRadio.checked ? 'create' : 'overwrite';
         
-        // 获取浏览器时区偏移（分钟）
+        // 获取浏览器时区偏移（分钟），用于创建模式的存档命名
+        // new Date().getTimezoneOffset() 返回 UTC 与本地时间的分钟差
+        // 取反得到本地时间相对于 UTC 的偏移
         const timezoneOffset = -new Date().getTimezoneOffset();
 
         // 覆盖模式必须提供目标标签
@@ -954,12 +1321,30 @@ document.addEventListener('DOMContentLoaded', function() {
         }
     }
 
+    // =========================== 确认对话框 ===========================
+
+    /**
+     * showConfirmDialog - 显示通用的确认对话框
+     * 
+     * 用于危险操作前的二次确认（删除、覆盖、加载存档等）。
+     * 
+     * 工作原理：
+     *   1. 设置对话框标题和消息内容
+     *   2. 保存回调函数到 confirmCallback 变量
+     *   3. 根据类型设置确认按钮样式（danger/primary）
+     *   4. 显示对话框
+     * 
+     * @param {string} title - 对话框标题
+     * @param {string} message - 对话框消息（支持 HTML）
+     * @param {Function} callback - 确认后执行的回调函数
+     * @param {string} confirmButtonType - 确认按钮类型 (danger|primary|secondary)
+     */
     function showConfirmDialog(title, message, callback, confirmButtonType = 'danger') { 
         const titleElement = document.getElementById('confirmModalLabel');
         const messageElement = document.getElementById('confirm-message');
 
         if (titleElement) {
-             titleElement.textContent = title;
+            titleElement.textContent = title;
         } else {
             console.error('[Cloud Saves UI] Confirm dialog title element (confirmModalLabel) not found!');
         }
@@ -970,8 +1355,10 @@ document.addEventListener('DOMContentLoaded', function() {
             console.error('[Cloud Saves UI] Confirm dialog message element (confirm-message) not found!');
         }
         
+        // 保存回调函数
         confirmCallback = callback;
         
+        // 设置确认按钮样式
         confirmActionBtn.classList.remove('btn-danger', 'btn-primary', 'btn-success', 'btn-warning', 'btn-secondary'); 
         if (confirmButtonType === 'danger') {
             confirmActionBtn.classList.add('btn-danger');
@@ -981,14 +1368,28 @@ document.addEventListener('DOMContentLoaded', function() {
             confirmActionBtn.classList.add('btn-secondary'); 
         }
         
+        // 显示对话框
         if (confirmModal && typeof confirmModal.show === 'function') {
-             confirmModal.show();
+            confirmModal.show();
         } else {
-             console.error('[Cloud Saves UI] Confirm dialog modal instance (confirmModal) is invalid or missing!');
-             showToast('错误', '无法显示确认对话框', 'error');
+            console.error('[Cloud Saves UI] Confirm dialog modal instance (confirmModal) is invalid or missing!');
+            showToast('错误', '无法显示确认对话框', 'error');
         }
     }
 
+    // =========================== 安全事件绑定工具 ===========================
+
+    /**
+     * safeAddEventListener - 安全的事件绑定封装
+     * 
+     * 在绑定事件前检查 DOM 元素是否存在，如果不存在则记录错误日志，
+     * 避免因 HTML 元素缺失导致的运行时错误。
+     * 
+     * @param {HTMLElement|null} element - DOM 元素
+     * @param {string} event - 事件名称 (如 'click')
+     * @param {Function} handler - 事件处理函数
+     * @param {string} elementIdForLogging - 用于日志记录的元素 ID
+     */
     function safeAddEventListener(element, event, handler, elementIdForLogging) {
         if (element) {
             element.addEventListener(event, handler);
@@ -997,7 +1398,9 @@ document.addEventListener('DOMContentLoaded', function() {
         }
     }
 
-    // 事件监听器绑定
+    // =========================== 事件监听器注册 ===========================
+
+    // --- 初始化仓库按钮 ---
     safeAddEventListener(initRepoBtn, 'click', () => {
         showConfirmDialog(
             '确认强制初始化仓库',
@@ -1006,75 +1409,114 @@ document.addEventListener('DOMContentLoaded', function() {
             'danger'
         );
     }, 'init-repo-btn');
+
+    // --- 配置按钮（只保存配置） ---
     safeAddEventListener(configureBtn, 'click', saveConfiguration, 'configure-btn');
+
+    // --- 授权并连接按钮 ---
     safeAddEventListener(authorizeBtn, 'click', async () => {
         const repoUrl = repoUrlInput.value.trim();
         const tokenInputValue = githubTokenInput.value.trim();
         const displayName = displayNameInput.value.trim();
         const branch = branchInput.value.trim() || 'main';
 
+        // 验证必要条件
         if (!repoUrl) {
             showToast('错误', '仓库 URL 不能为空', 'error');
             return;
         }
+        // 如果用户输入了新 token，提示先保存
         if (tokenInputValue && tokenInputValue !== "") {
             showToast('提示', '检测到新的访问令牌输入，请先点击"配置"按钮保存新令牌，然后再点击"授权并连接"。', 'info');
             return;
         }
+        // 验证是否有已保存的 token
         if (!tokenInputValue && !initialConfigHasToken) {
             showToast('错误', 'GitHub 访问令牌不能为空，请在上方输入或点击"配置"保存。', 'error');
             return;
         }
 
         await authorize(repoUrl, displayName, branch);
-
     }, 'authorize-btn');
+
+    // --- 断开连接按钮 ---
     safeAddEventListener(logoutBtn, 'click', () => {
         showConfirmDialog('确认断开连接', '您确定要断开与仓库的连接吗？这将不会删除任何数据。', logout, 'primary');
     }, 'logout-btn');
+
+    // --- 创建存档按钮 ---
     safeAddEventListener(createSaveBtn, 'click', () => {
         createSave(saveNameInput.value, saveDescriptionInput.value);
     }, 'create-save-btn');
+
+    // --- 确认重命名按钮（模态框中） ---
     safeAddEventListener(confirmRenameBtn, 'click', () => {
         renameSave(renameTagNameInput.value, renameNewNameInput.value, renameDescriptionInput.value);
         renameModal.hide();
     }, 'confirm-rename-btn');
+
+    // --- 确认对话框的确认按钮 ---
     safeAddEventListener(confirmActionBtn, 'click', () => {
+        // 执行之前通过 showConfirmDialog 注册的回调函数
         if (typeof confirmCallback === 'function') {
             confirmCallback();
         }
         confirmModal.hide();
     }, 'confirm-action-btn');
+
+    // --- 刷新存档列表按钮 ---
     safeAddEventListener(refreshSavesBtn, 'click', loadSavesList, 'refresh-saves-btn');
+
+    // --- 搜索框输入事件（实时过滤） ---
     safeAddEventListener(searchBox, 'input', filterAndSortSaves, 'search-box');
+
+    // --- 排序下拉框变更事件 ---
     safeAddEventListener(sortSelector, 'change', filterAndSortSaves, 'sort-selector');
+
+    // --- 应用 Stash 按钮 ---
     safeAddEventListener(applyStashBtn, 'click', applyStash, 'apply-stash-btn');
+
+    // --- 丢弃 Stash 按钮（需要确认） ---
     safeAddEventListener(discardStashBtn, 'click', () => {
         showConfirmDialog('确认丢弃临时更改', '您确定要丢弃所有临时保存的更改吗？此操作无法撤销。', discardStash, 'danger');
     }, 'discard-stash-btn');
+
+    // --- 自动存档启用开关 ---
     safeAddEventListener(autoSaveEnabledSwitch, 'change', () => {
+        // 切换选项区域的显示/隐藏
         autoSaveOptionsDiv.style.display = autoSaveEnabledSwitch.checked ? 'flex' : 'none';
     }, 'auto-save-enabled');
 
-    // 自动存档模式切换事件
+    // --- 自动存档模式：覆盖 ---
     safeAddEventListener(autoSaveModeOverwriteRadio, 'change', () => {
         if (autoSaveModeOverwriteRadio.checked) {
-            autoSaveTargetTagRow.style.display = '';
+            autoSaveTargetTagRow.style.display = '';  // 显示目标标签输入
             autoSaveModeHint.textContent = '覆盖模式：每次自动存档将覆盖指定的已有存档标签。';
         }
     }, 'auto-save-mode-overwrite');
 
+    // --- 自动存档模式：创建 ---
     safeAddEventListener(autoSaveModeCreateRadio, 'change', () => {
         if (autoSaveModeCreateRadio.checked) {
-            autoSaveTargetTagRow.style.display = 'none';
+            autoSaveTargetTagRow.style.display = 'none';  // 隐藏目标标签输入
             autoSaveModeHint.textContent = '创建模式：每次自动存档将创建新存档（命名格式：YYYY-MM-DD - HHMM (Auto Save)），使用浏览器时区。';
         }
     }, 'auto-save-mode-create');
 
+    // --- 保存定时存档设置按钮 ---
     safeAddEventListener(saveAutoSaveSettingsBtn, 'click', saveAutoSaveConfiguration, 'save-auto-save-settings-btn');
 
+    // --- 检查更新按钮 ---
     safeAddEventListener(checkUpdateBtn, 'click', checkAndApplyUpdate, 'check-update-btn');
 
+    // =========================== 初始化仓库 ===========================
+
+    /**
+     * initializeRepository - 强制重新初始化本地 Git 仓库
+     * 
+     * 删除 data 目录下现有的 .git 目录，然后重新执行 git init。
+     * 这是一个破坏性操作，需要用户确认。
+     */
     async function initializeRepository() {
         try {
             showLoading('正在初始化仓库...');
@@ -1084,11 +1526,10 @@ document.addEventListener('DOMContentLoaded', function() {
                 let message = result.message || '仓库初始化成功';
                 if (result.warning) {
                     showToast('警告', message, 'warning');
-                    showToast('提示', '初始化完成，请点击 **授权并连接** 按钮以验证并同步远程仓库。', 'info');
                 } else {
                     showToast('成功', message, 'success');
-                    showToast('提示', '初始化完成，请点击 **授权并连接** 按钮以验证并同步远程仓库。', 'info');
                 }
+                showToast('提示', '初始化完成，请点击 **授权并连接** 按钮以验证并同步远程仓库。', 'info');
                 await refreshStatus();
             } else {
                 throw new Error(result.message || '初始化仓库失败');
@@ -1102,6 +1543,19 @@ document.addEventListener('DOMContentLoaded', function() {
         }
     }
 
+    // =========================== 检查插件更新 ===========================
+
+    /**
+     * checkAndApplyUpdate - 检查插件自身是否有更新
+     * 
+     * 使用插件目录的 Git 仓库检查是否有新提交。
+     * 如果有更新，自动执行 git pull。
+     * 
+     * 可能的状态：
+     *   - not_git_repo: 插件不是通过 Git 安装的，无法自动更新
+     *   - latest: 已是最新版本
+     *   - updated: 更新成功，需要重启 SillyTavern
+     */
     async function checkAndApplyUpdate() {
         try {
             showLoading('正在检查插件更新...');
@@ -1112,17 +1566,17 @@ document.addEventListener('DOMContentLoaded', function() {
                 let type = 'info';
                 if (result.status === 'latest') {
                     type = 'success';
-                    message = '插件已是最新版本。'
+                    message = '插件已是最新版本。';
                 } else if (result.status === 'updated') {
                     type = 'success';
                     message = '插件更新成功！请务必重启 SillyTavern 服务以应用更改。';
                 } else if (result.status === 'not_git_repo') {
                     type = 'warning';
-                    message = '无法自动更新：插件似乎不是通过 Git 安装的。'
+                    message = '无法自动更新：插件似乎不是通过 Git 安装的。';
                 }
                 showToast('检查更新', message, type);
             } else {
-                 showToast('更新失败', result.message || '检查或应用更新时发生未知错误。', 'error');
+                showToast('更新失败', result.message || '检查或应用更新时发生未知错误。', 'error');
             }
 
             hideLoading();
@@ -1133,12 +1587,22 @@ document.addEventListener('DOMContentLoaded', function() {
         }
     }
 
+    // =========================== Token 输入框交互优化 ===========================
+
+    /**
+     * Token 输入框获得焦点时：
+     * 如果占位符显示"已保存"，替换为提示输入新 token 的文字
+     */
     safeAddEventListener(githubTokenInput, 'focus', () => {
         if (githubTokenInput.placeholder === "访问令牌已保存") {
             githubTokenInput.placeholder = "输入新令牌以覆盖...";
         }
     }, 'github-token-focus');
 
+    /**
+     * Token 输入框失去焦点时：
+     * 如果用户清空了输入框，根据是否有已保存的 token 恢复对应的占位符文字
+     */
     safeAddEventListener(githubTokenInput, 'blur', () => {
         if (githubTokenInput.value === "" && initialConfigHasToken) {
             githubTokenInput.placeholder = "访问令牌已保存";
@@ -1147,7 +1611,8 @@ document.addEventListener('DOMContentLoaded', function() {
         }
     }, 'github-token-blur');
 
-    // 初始化
+    // =========================== 初始化启动 ===========================
+    // 页面加载完成后立即执行初始化
     init();
 
 }); // DOMContentLoaded 结束

--- a/public/script.js
+++ b/public/script.js
@@ -664,26 +664,25 @@ document.addEventListener('DOMContentLoaded', function() {
     // 创建存档
     async function createSave(name, description) {
         try {
-            // 修改：如果存檔名稱為空或只有空格，則自動生成香港時間的存檔名稱
-            if (!name || name.trim() === '') {
-                // 強制轉換為 Asia/Hong Kong 時區
-                const hkNow = new Date(new Date().toLocaleString("en-US", { timeZone: "Asia/Hong Kong" }));
-                
-                const yyyy = hkNow.getFullYear();
-                // padStart 確保月份、日期、小時、分鐘永遠是兩位數
-                const mm = String(hkNow.getMonth() + 1).padStart(2, '0'); 
-                const dd = String(hkNow.getDate()).padStart(2, '0');
-                const hh = String(hkNow.getHours()).padStart(2, '0');
-                const min = String(hkNow.getMinutes()).padStart(2, '0');
-                
-                // 組合成 YYYY-MM-DD - HHMM
-                name = `${yyyy}-${mm}-${dd} - ${hh}${min}`;
+            let finalName = name ? name.trim() : '';
+            
+            // 核心修改點：如果存檔名稱留空，則自動以瀏覽使用者的當地時區生成時間格式
+            if (finalName === '') {
+                // new Date() 是前端瀏覽器原生函數，保證生成的是當前網頁使用者的當地時區，與伺服器時區無關
+                const now = new Date();
+                const year = now.getFullYear();
+                const month = String(now.getMonth() + 1).padStart(2, '0');
+                const day = String(now.getDate()).padStart(2, '0');
+                const hours = String(now.getHours()).padStart(2, '0');
+                const minutes = String(now.getMinutes()).padStart(2, '0');
+                // 格式化為: YYYY-MM-DD - HHMM
+                finalName = `${year}-${month}-${day} - ${hours}${minutes}`;
             }
             
             showLoading('正在创建存档...');
             
             const result = await apiCall('saves', 'POST', {
-                name: name,
+                name: finalName,
                 description: description
             });
             

--- a/public/script.js
+++ b/public/script.js
@@ -664,9 +664,20 @@ document.addEventListener('DOMContentLoaded', function() {
     // 创建存档
     async function createSave(name, description) {
         try {
+            // 修改：如果存檔名稱為空或只有空格，則自動生成香港時間的存檔名稱
             if (!name || name.trim() === '') {
-                showToast('错误', '存档名称不能为空', 'error');
-                return;
+                // 強制轉換為 Asia/Hong Kong 時區
+                const hkNow = new Date(new Date().toLocaleString("en-US", { timeZone: "Asia/Hong Kong" }));
+                
+                const yyyy = hkNow.getFullYear();
+                // padStart 確保月份、日期、小時、分鐘永遠是兩位數
+                const mm = String(hkNow.getMonth() + 1).padStart(2, '0'); 
+                const dd = String(hkNow.getDate()).padStart(2, '0');
+                const hh = String(hkNow.getHours()).padStart(2, '0');
+                const min = String(hkNow.getMinutes()).padStart(2, '0');
+                
+                // 組合成 YYYY-MM-DD - HHMM
+                name = `${yyyy}-${mm}-${dd} - ${hh}${min}`;
             }
             
             showLoading('正在创建存档...');

--- a/public/script.js
+++ b/public/script.js
@@ -930,7 +930,7 @@ document.addEventListener('DOMContentLoaded', function() {
                 const day = String(now.getDate()).padStart(2, '0');
                 const hours = String(now.getHours()).padStart(2, '0');
                 const minutes = String(now.getMinutes()).padStart(2, '0');
-                finalName = `${year}-${month}-${day} - ${hours}${minutes}`;
+                finalName = `${year}-${month}-${day} | ${hours}${minutes}`;
             }
             
             showLoading('正在创建存档...');

--- a/public/script.js
+++ b/public/script.js
@@ -5,7 +5,7 @@ document.addEventListener('DOMContentLoaded', function() {
     let currentSaves = [];
     let confirmCallback = null;
     let renameTarget = null;
-    let initialConfigHasToken = false; // 新增：用于跟踪初始加载时是否有token
+    let initialConfigHasToken = false;
 
     // 获取DOM元素引用
     const authSection = document.getElementById('auth-section');
@@ -18,7 +18,7 @@ document.addEventListener('DOMContentLoaded', function() {
     const configureBtn = document.getElementById('configure-btn');
     const authorizeBtn = document.getElementById('authorize-btn');
     const logoutBtn = document.getElementById('logout-btn');
-    const initRepoBtn = document.getElementById('init-repo-btn'); // 新增
+    const initRepoBtn = document.getElementById('init-repo-btn');
 
     const createSaveSection = document.getElementById('create-save-section');
     const saveNameInput = document.getElementById('save-name');
@@ -58,7 +58,7 @@ document.addEventListener('DOMContentLoaded', function() {
     const diffSummary = document.getElementById('diff-summary');
     const diffFiles = document.getElementById('diff-files');
 
-    // 新增：定时存档 UI 元素
+    // 定时存档 UI 元素
     const autoSaveSection = document.getElementById('auto-save-section');
     const autoSaveEnabledSwitch = document.getElementById('auto-save-enabled');
     const autoSaveOptionsDiv = document.getElementById('auto-save-options');
@@ -66,7 +66,13 @@ document.addEventListener('DOMContentLoaded', function() {
     const autoSaveTargetTagInput = document.getElementById('auto-save-target-tag');
     const saveAutoSaveSettingsBtn = document.getElementById('save-auto-save-settings-btn');
 
-    // 新增：检查更新按钮
+    // 自动存档模式切换元素
+    const autoSaveModeOverwriteRadio = document.getElementById('auto-save-mode-overwrite');
+    const autoSaveModeCreateRadio = document.getElementById('auto-save-mode-create');
+    const autoSaveModeHint = document.getElementById('auto-save-mode-hint');
+    const autoSaveTargetTagRow = document.getElementById('auto-save-target-tag-row');
+
+    // 检查更新按钮
     const checkUpdateBtn = document.getElementById('check-update-btn');
 
     // API调用工具函数
@@ -93,7 +99,7 @@ document.addEventListener('DOMContentLoaded', function() {
             } catch (csrfError) {
                 console.error('无法获取或设置CSRF令牌:', csrfError);
                 showToast('错误', `无法执行操作，获取安全令牌失败: ${csrfError.message}`, 'error');
-                throw csrfError; // 阻止后续请求
+                throw csrfError;
             }
         }
 
@@ -103,7 +109,6 @@ document.addEventListener('DOMContentLoaded', function() {
 
         try {
             const response = await fetch(`/api/plugins/cloud-saves/${endpoint}`, options);
-            // 检查是否是 CSRF 错误导致的 HTML 响应
             if (!response.ok && response.headers.get('content-type')?.includes('text/html')) {
                  if (response.status === 403) {
                      throw new Error('认证或权限错误 (403 Forbidden)。可能是CSRF令牌问题或GitHub Token权限不足。');
@@ -115,14 +120,12 @@ document.addEventListener('DOMContentLoaded', function() {
             const result = await response.json();
             
             if (!response.ok) {
-                // 使用后端返回的 message 或构造一个
                 throw new Error(result.message || `请求失败，状态码: ${response.status}`); 
             }
             
             return result;
         } catch (error) {
             console.error(`API调用失败 (${endpoint}):`, error);
-            // 避免重复显示CSRF令牌获取失败的Toast
             if (!error.message.includes('安全令牌失败')) {
                  showToast('错误', `操作失败: ${error.message}`, 'error');
             }
@@ -149,7 +152,6 @@ document.addEventListener('DOMContentLoaded', function() {
         toast.setAttribute('aria-live', 'assertive');
         toast.setAttribute('aria-atomic', 'true');
         
-        // 根据类型设置边框颜色
         if (type === 'success') {
             toast.style.borderLeft = '4px solid var(--bs-success)';
         } else if (type === 'error' || type === 'danger') {
@@ -160,7 +162,6 @@ document.addEventListener('DOMContentLoaded', function() {
             toast.style.borderLeft = '4px solid var(--bs-primary)';
         }
         
-        // 设置内容
         toast.innerHTML = `
             <div class="toast-header">
                 <strong class="me-auto">${title}</strong>
@@ -171,7 +172,6 @@ document.addEventListener('DOMContentLoaded', function() {
         
         toastContainer.appendChild(toast);
         
-        // 自动关闭
         setTimeout(() => {
             toast.classList.remove('show');
             setTimeout(() => {
@@ -179,7 +179,6 @@ document.addEventListener('DOMContentLoaded', function() {
             }, 300);
         }, 5000);
         
-        // 点击关闭按钮
         toast.querySelector('.btn-close').addEventListener('click', () => {
             toast.classList.remove('show');
             setTimeout(() => {
@@ -197,20 +196,34 @@ document.addEventListener('DOMContentLoaded', function() {
             if (config.display_name) displayNameInput.value = config.display_name;
             if (config.branch) branchInput.value = config.branch;
             
-            // --- Token Input Handling ---
-            initialConfigHasToken = config.has_github_token; // 记录初始状态
+            // Token Input Handling
+            initialConfigHasToken = config.has_github_token;
             if (initialConfigHasToken) {
-                githubTokenInput.placeholder = "访问令牌已保存"; // 设置提示
-                githubTokenInput.value = ""; // 确保实际值为空
+                githubTokenInput.placeholder = "访问令牌已保存";
+                githubTokenInput.value = "";
             } else {
-                githubTokenInput.placeholder = "例如: ghp_xxxxxxxxxxxx"; // 默认提示
+                githubTokenInput.placeholder = "例如: ghp_xxxxxxxxxxxx";
                 githubTokenInput.value = "";
             }
-            // --- End Token Input Handling ---
             
             autoSaveEnabledSwitch.checked = config.autoSaveEnabled || false;
             autoSaveIntervalInput.value = config.autoSaveInterval || 30;
             autoSaveTargetTagInput.value = config.autoSaveTargetTag || '';
+
+            // 设置自动存档模式
+            const savedMode = config.autoSaveMode || 'overwrite';
+            if (savedMode === 'create') {
+                autoSaveModeCreateRadio.checked = true;
+                autoSaveModeOverwriteRadio.checked = false;
+                autoSaveTargetTagRow.style.display = 'none';
+                autoSaveModeHint.textContent = '创建模式：每次自动存档将创建新存档（命名格式：YYYY-MM-DD - HHMM (Auto Save)），使用浏览器时区。';
+            } else {
+                autoSaveModeOverwriteRadio.checked = true;
+                autoSaveModeCreateRadio.checked = false;
+                autoSaveTargetTagRow.style.display = '';
+                autoSaveModeHint.textContent = '覆盖模式：每次自动存档将覆盖指定的已有存档标签。';
+            }
+
             autoSaveOptionsDiv.style.display = autoSaveEnabledSwitch.checked ? 'flex' : 'none';
             
             isAuthorized = config.is_authorized;
@@ -222,19 +235,17 @@ document.addEventListener('DOMContentLoaded', function() {
                 await loadSavesList();
             }
         } catch (error) {
-            // 初始化失败时，也重置 token 输入框状态
             githubTokenInput.placeholder = "例如: ghp_xxxxxxxxxxxx";
             githubTokenInput.value = "";
             initialConfigHasToken = false;
         }
     }
 
-    // 更新授权UI (MODIFIED - 登出时重置 token 输入框)
+    // 更新授权UI
     function updateAuthUI(authorized) {
-        isAuthorized = authorized; // Update global state
+        isAuthorized = authorized;
 
         if (authorized) {
-            // --- UI for Authorized State ---
             authStatus.innerHTML = `<i class="bi bi-check-circle-fill text-success me-2"></i>已成功授权`;
             authStatus.classList.remove('alert-danger');
             authStatus.classList.add('alert-success');
@@ -244,34 +255,27 @@ document.addEventListener('DOMContentLoaded', function() {
             savesSection.style.display = 'block';
             autoSaveSection.style.display = 'block';
 
-            // Set placeholder based on whether a token is actually configured
             if (initialConfigHasToken) {
                 githubTokenInput.placeholder = "访问令牌已保存";
                 githubTokenInput.value = "";
             } else {
-                // Edge case: Authorized but somehow no token? Should not happen.
                 githubTokenInput.placeholder = "例如: ghp_xxxxxxxxxxxx";
                 githubTokenInput.value = "";
             }
         } else {
-            // --- UI for Non-Authorized State ---
             authStatus.style.display = 'none';
             logoutBtn.style.display = 'none';
             createSaveSection.style.display = 'none';
             savesSection.style.display = 'none';
             autoSaveSection.style.display = 'none';
 
-            // Set placeholder based on whether a token is configured (even if not authorized)
             if (initialConfigHasToken) {
-                 // Keep showing "已保存" as a hint that backend has it
                 githubTokenInput.placeholder = "访问令牌已保存";
                 githubTokenInput.value = "";
             } else {
-                 // No token configured, show default prompt
                 githubTokenInput.placeholder = "例如: ghp_xxxxxxxxxxxx";
                 githubTokenInput.value = "";
             }
-            // NOTE: DO NOT reset initialConfigHasToken here. It reflects backend state.
         }
     }
 
@@ -283,14 +287,12 @@ document.addEventListener('DOMContentLoaded', function() {
             if (statusResult.success && statusResult.status) {
                 const status = statusResult.status;
                 
-                // 更新Git初始化状态
                 if (status.initialized) {
                     gitStatus.innerHTML = `<i class="bi bi-check-circle-fill text-success me-2"></i>Git仓库就绪`;
                 } else {
                     gitStatus.innerHTML = `<i class="bi bi-circle-fill text-secondary me-2"></i>Git仓库未初始化`;
                 }
                 
-                // 更新更改状态
                 if (status.changes && status.changes.length > 0) {
                     changesCount.textContent = status.changes.length;
                     changesStatus.style.display = 'inline';
@@ -298,7 +300,6 @@ document.addEventListener('DOMContentLoaded', function() {
                     changesStatus.style.display = 'none';
                 }
                 
-                // 更新当前存档状态
                 if (status.currentSave) {
                     const saveNameMatch = status.currentSave.tag.match(/^save_\d+_(.+)$/);
                     const saveName = saveNameMatch ? saveNameMatch[1] : status.currentSave.tag;
@@ -307,7 +308,6 @@ document.addEventListener('DOMContentLoaded', function() {
                     currentSaveStatus.textContent = '未加载任何存档';
                 }
                 
-                // 检查临时stash状态
                 if (status.tempStash && status.tempStash.exists) {
                     stashNotification.style.display = 'block';
                 } else {
@@ -345,25 +345,21 @@ document.addEventListener('DOMContentLoaded', function() {
 
     // 渲染存档列表
     function renderSavesList(saves) {
-        // 先清空容器
         while (savesContainer.firstChild) {
             savesContainer.removeChild(savesContainer.firstChild);
         }
         
-        // 检查是否有存档
         if (saves.length === 0) {
             savesContainer.appendChild(noSavesMessage);
             return;
         }
         
-        // 获取当前加载的存档
         let currentLoadedSave = null;
         
         apiCall('config').then(config => {
             if (config.current_save && config.current_save.tag) {
                 currentLoadedSave = config.current_save.tag;
                 
-                // 更新已渲染的存档卡片
                 const currentSaveCard = document.querySelector(`.save-card[data-tag="${currentLoadedSave}"]`);
                 if (currentSaveCard) {
                     const badge = document.createElement('div');
@@ -374,7 +370,6 @@ document.addEventListener('DOMContentLoaded', function() {
             }
         });
         
-        // 创建存档卡片
         saves.forEach(save => {
             const saveCard = document.createElement('div');
             saveCard.classList.add('card', 'save-card', 'mb-3');
@@ -383,7 +378,6 @@ document.addEventListener('DOMContentLoaded', function() {
             const saveDate = new Date(save.timestamp);
             const formattedDate = saveDate.toLocaleString();
             
-            // 使用新的时间戳字段
             const createdAtDate = new Date(save.createdAt);
             const updatedAtDate = new Date(save.updatedAt);
             const formattedCreatedAt = createdAtDate.toLocaleString();
@@ -401,7 +395,6 @@ document.addEventListener('DOMContentLoaded', function() {
                             </div>
                             <div class="save-creator mb-2">操作人: ${creatorName}</div>
                             <div class="save-description">${descriptionText}</div>
-                            <!-- 新增：显示并可复制标签名 -->
                             <div class="save-tag-info mt-2">
                                 <small class="text-muted">标签名: <code class="user-select-all">${save.tag}</code></small>
                                 <button class="btn btn-sm btn-outline-secondary copy-tag-btn ms-1" data-tag="${save.tag}" title="复制标签名">
@@ -430,7 +423,6 @@ document.addEventListener('DOMContentLoaded', function() {
                 </div>
             `;
             
-            // 如果是当前加载的存档，添加标记
             if (save.tag === currentLoadedSave) {
                 const badge = document.createElement('div');
                 badge.classList.add('save-current-badge');
@@ -441,13 +433,11 @@ document.addEventListener('DOMContentLoaded', function() {
             savesContainer.appendChild(saveCard);
         });
         
-        // 注册按钮事件
         registerSaveCardEvents();
     }
     
     // 注册存档卡片按钮事件
     function registerSaveCardEvents() {
-        // 加载存档按钮
         document.querySelectorAll('.load-save-btn').forEach(btn => {
             btn.addEventListener('click', async function() {
                 const tagName = this.dataset.tag;
@@ -461,7 +451,6 @@ document.addEventListener('DOMContentLoaded', function() {
             });
         });
         
-        // 重命名存档按钮
         document.querySelectorAll('.rename-save-btn').forEach(btn => {
             btn.addEventListener('click', function() {
                 renameTarget = this.dataset.tag;
@@ -472,23 +461,21 @@ document.addEventListener('DOMContentLoaded', function() {
             });
         });
         
-        // 覆盖存档按钮
         document.querySelectorAll('.overwrite-save-btn').forEach(btn => {
             btn.addEventListener('click', function() {
                 const tagName = this.dataset.tag;
-                const saveName = this.dataset.name || tagName; // 获取存档名用于提示
+                const saveName = this.dataset.name || tagName;
                 showConfirmDialog(
                     `确认覆盖存档 "${saveName}"`,
                     `<strong>警告：此操作不可逆！</strong><br>您确定要用当前本地的 SillyTavern 数据覆盖云端的 "${saveName}" 存档吗？云端该存档之前的内容将会丢失。`,
                     async () => {
                         await overwriteSave(tagName);
                     },
-                    'danger' // 使用危险确认按钮样式
+                    'danger'
                 );
             });
         });
         
-        // 删除存档按钮
         document.querySelectorAll('.delete-save-btn').forEach(btn => {
             btn.addEventListener('click', function() {
                 const tagName = this.dataset.tag;
@@ -502,11 +489,9 @@ document.addEventListener('DOMContentLoaded', function() {
             });
         });
         
-        // 比较差异按钮
         document.querySelectorAll('.diff-save-btn').forEach(btn => {
             btn.addEventListener('click', async function() {
                 const tagName = this.dataset.tag;
-                // 再次尝试获取存档名称，添加日志调试
                 const saveName = this.dataset.name;
                 console.log('Comparing save:', tagName, 'Name from dataset:', saveName);
                 if (!saveName) {
@@ -516,19 +501,14 @@ document.addEventListener('DOMContentLoaded', function() {
                 try {
                     showLoading('正在加载差异...');
                     
-                    // --- BEGIN REVERT DIFF LOGIC ---
-                    // 恢复为比较标签和当前 HEAD
                     const tagRef1 = encodeURIComponent(tagName);
-                    const tagRef2 = 'HEAD'; // 直接使用 HEAD
+                    const tagRef2 = 'HEAD';
                     const result = await apiCall(`saves/diff?tag1=${tagRef1}&tag2=${tagRef2}`);
-                    // --- END REVERT DIFF LOGIC ---
                     
                     if (result.success) {
-                        // 更新模态框标题，确保 saveName 有值
                         const diffModalLabel = document.getElementById('diffModalLabel');
-                        diffModalLabel.textContent = `存档 "${saveName || tagName}" 与当前状态的差异`; // 使用 tagname 作为备用
+                        diffModalLabel.textContent = `存档 "${saveName || tagName}" 与当前状态的差异`;
                         
-                        // 隐藏统计信息区域 (保持不变)
                         diffSummary.innerHTML = ''; 
                         diffSummary.style.display = 'none'; 
                         
@@ -555,7 +535,7 @@ document.addEventListener('DOMContentLoaded', function() {
                             });
                             diffFiles.appendChild(fileList);
                         } else {
-                            diffFiles.innerHTML = '<p class="text-center text-secondary mt-3">此存档与当前状态没有文件差异。</p>'; // 更新无差异消息
+                            diffFiles.innerHTML = '<p class="text-center text-secondary mt-3">此存档与当前状态没有文件差异。</p>';
                         }
                         
                         hideLoading();
@@ -571,19 +551,17 @@ document.addEventListener('DOMContentLoaded', function() {
             });
         });
 
-        // --- 新增：复制标签名按钮事件 ---
         document.querySelectorAll('.copy-tag-btn').forEach(btn => {
             btn.addEventListener('click', function() {
                 const tagName = this.dataset.tag;
                 navigator.clipboard.writeText(tagName).then(() => {
-                    // 短暂改变图标提示成功
                     const icon = this.querySelector('i');
                     const originalIconClass = icon.className;
                     icon.className = 'bi bi-check-lg text-success'; 
                     showToast('提示', '标签名已复制到剪贴板', 'info');
                     setTimeout(() => {
                         icon.className = originalIconClass;
-                    }, 1500); // 1.5秒后恢复图标
+                    }, 1500);
                 }).catch(err => {
                     console.error('复制标签名失败:', err);
                     showToast('错误', '复制标签名失败', 'error');
@@ -602,7 +580,6 @@ document.addEventListener('DOMContentLoaded', function() {
             if (result.success) {
                 showToast('成功', '存档加载成功', 'success');
                 await refreshStatus();
-                // 高亮显示逻辑不需要改变
                 highlightCurrentSave(tagName);
             } else {
                 throw new Error(result.message || '加载存档失败');
@@ -616,7 +593,6 @@ document.addEventListener('DOMContentLoaded', function() {
         }
     }
 
-    // --- 新增：高亮当前存档的辅助函数 ---
     function highlightCurrentSave(tagName) {
         document.querySelectorAll('.save-current-badge').forEach(badge => badge.remove());
         const saveCard = document.querySelector(`.save-card[data-tag="${tagName}"]`);
@@ -636,18 +612,15 @@ document.addEventListener('DOMContentLoaded', function() {
             const result = await apiCall(`saves/${tagName}`, 'DELETE');
             
             if (result.success) {
-                // 如果删除成功但有警告
                 if (result.warning) {
                     showToast('警告', result.message, 'warning');
                 } else {
                     showToast('成功', '存档已删除', 'success');
                 }
                 
-                // 从列表移除
                 currentSaves = currentSaves.filter(save => save.tag !== tagName);
                 renderSavesList(currentSaves);
                 
-                // 刷新状态
                 await refreshStatus();
             } else {
                 throw new Error(result.message || '删除存档失败');
@@ -666,16 +639,13 @@ document.addEventListener('DOMContentLoaded', function() {
         try {
             let finalName = name ? name.trim() : '';
             
-            // 核心修改點：如果存檔名稱留空，則自動以瀏覽使用者的當地時區生成時間格式
             if (finalName === '') {
-                // new Date() 是前端瀏覽器原生函數，保證生成的是當前網頁使用者的當地時區，與伺服器時區無關
                 const now = new Date();
                 const year = now.getFullYear();
                 const month = String(now.getMonth() + 1).padStart(2, '0');
                 const day = String(now.getDate()).padStart(2, '0');
                 const hours = String(now.getHours()).padStart(2, '0');
                 const minutes = String(now.getMinutes()).padStart(2, '0');
-                // 格式化為: YYYY-MM-DD - HHMM
                 finalName = `${year}-${month}-${day} - ${hours}${minutes}`;
             }
             
@@ -689,11 +659,9 @@ document.addEventListener('DOMContentLoaded', function() {
             if (result.success) {
                 showToast('成功', '存档创建成功', 'success');
                 
-                // 清空输入
                 saveNameInput.value = '';
                 saveDescriptionInput.value = '';
                 
-                // 刷新列表
                 await loadSavesList();
                 await refreshStatus();
             } else {
@@ -726,7 +694,6 @@ document.addEventListener('DOMContentLoaded', function() {
             if (result.success) {
                 showToast('成功', '存档重命名成功', 'success');
                 
-                // 刷新列表
                 await loadSavesList();
             } else {
                 throw new Error(result.message || '重命名存档失败');
@@ -740,10 +707,8 @@ document.addEventListener('DOMContentLoaded', function() {
         }
     }
 
-    // --- 授权函数 (MODIFIED - 移除内部 token 检查) ---
-    async function authorize(repoUrl, displayName, branch) { // 移除 token 参数
+    async function authorize(repoUrl, displayName, branch) {
         try {
-            // URL 检查还是需要的，可以在调用前做，或者保留在这里
             if (!repoUrl) {
                  showToast('错误', '仓库 URL 不能为空', 'error');
                  return;
@@ -751,14 +716,13 @@ document.addEventListener('DOMContentLoaded', function() {
 
             showLoading('正在授权并连接仓库...');
 
-            // 注意：/authorize 接口不需要传递 token，它会从后端配置读取
             const result = await apiCall('authorize', 'POST', {
-                branch: branch // 只传递分支信息
+                branch: branch
             });
 
             if (result.success) {
                 isAuthorized = true;
-                updateAuthUI(true); // 会根据 initialConfigHasToken 设置 placeholder
+                updateAuthUI(true);
                 await refreshStatus();
                 await loadSavesList();
                 showToast('成功', '仓库授权成功！', 'success');
@@ -780,21 +744,18 @@ document.addEventListener('DOMContentLoaded', function() {
         }
     }
 
-    // 登出/断开连接 (MODIFIED - Explicitly reset flag)
     async function logout() {
         try {
             showLoading('正在断开连接...');
 
-            // Send is_authorized: false to backend. Backend POST /config doesn't need other fields.
             await apiCall('config', 'POST', {
-                github_token: '', // Send empty, backend ignores if no new token needed
-                is_authorized: false // 核心是这个
+                github_token: '',
+                is_authorized: false
             });
 
             isAuthorized = false;
-            initialConfigHasToken = false; // Explicitly reset the flag on logout
-            updateAuthUI(false); // Update UI (which will now correctly set placeholder to default based on the reset flag)
-            // githubTokenInput.value = ''; // updateAuthUI handles this via the !initialConfigHasToken check
+            initialConfigHasToken = false;
+            updateAuthUI(false);
 
             hideLoading();
             showToast('成功', '已断开与仓库的连接', 'success');
@@ -805,7 +766,6 @@ document.addEventListener('DOMContentLoaded', function() {
         }
     }
 
-    // 应用临时stash
     async function applyStash() {
         try {
             showLoading('正在恢复临时更改...');
@@ -816,7 +776,6 @@ document.addEventListener('DOMContentLoaded', function() {
                 stashNotification.style.display = 'none';
                 showToast('成功', '临时更改已恢复', 'success');
                 
-                // 刷新状态
                 await refreshStatus();
             } else {
                 throw new Error(result.message || '恢复临时更改失败');
@@ -830,7 +789,6 @@ document.addEventListener('DOMContentLoaded', function() {
         }
     }
 
-    // 丢弃临时stash
     async function discardStash() {
         try {
             showLoading('正在丢弃临时更改...');
@@ -841,7 +799,6 @@ document.addEventListener('DOMContentLoaded', function() {
                 stashNotification.style.display = 'none';
                 showToast('成功', '临时更改已丢弃', 'success');
                 
-                // 刷新状态
                 await refreshStatus();
             } else {
                 throw new Error(result.message || '丢弃临时更改失败');
@@ -855,7 +812,6 @@ document.addEventListener('DOMContentLoaded', function() {
         }
     }
 
-    // 覆盖存档
     async function overwriteSave(tagName) {
         try {
             showLoading('正在覆盖存档...');
@@ -864,7 +820,6 @@ document.addEventListener('DOMContentLoaded', function() {
             
             if (result.success) {
                 showToast('成功', '存档已成功覆盖', 'success');
-                // 覆盖后通常需要刷新列表，因为时间戳等信息可能更新 (取决于后端实现)
                 await loadSavesList(); 
                 await refreshStatus();
             } else {
@@ -879,14 +834,12 @@ document.addEventListener('DOMContentLoaded', function() {
         }
     }
 
-    // 过滤和排序存档列表
     function filterAndSortSaves() {
         if (!currentSaves || currentSaves.length === 0) return;
         
         const searchTerm = searchBox.value.toLowerCase();
         const sortMethod = sortSelector.value;
         
-        // 筛选
         let filteredSaves = currentSaves;
         if (searchTerm) {
             filteredSaves = currentSaves.filter(save => 
@@ -895,12 +848,11 @@ document.addEventListener('DOMContentLoaded', function() {
             );
         }
         
-        // 排序
         filteredSaves.sort((a, b) => {
             switch (sortMethod) {
-                case 'updated-desc': // 使用新的值
+                case 'updated-desc':
                     return new Date(b.updatedAt) - new Date(a.updatedAt);
-                case 'updated-asc': // 使用新的值
+                case 'updated-asc':
                     return new Date(a.updatedAt) - new Date(b.updatedAt);
                 case 'name-asc':
                     return a.name.localeCompare(b.name);
@@ -914,7 +866,6 @@ document.addEventListener('DOMContentLoaded', function() {
         renderSavesList(filteredSaves);
     }
 
-    // 保存配置函数
     async function saveConfiguration() {
         const repoUrl = repoUrlInput.value.trim();
         const token = githubTokenInput.value.trim();
@@ -925,32 +876,26 @@ document.addEventListener('DOMContentLoaded', function() {
             showLoading('正在保存配置...');
             const result = await apiCall('config', 'POST', {
                 repo_url: repoUrl,
-                github_token: token, // 发送实际输入值 (可能是空)
+                github_token: token,
                 display_name: displayName,
                 branch: branch
-                // 注意：这里不发送 is_authorized, autoSave* 等字段，避免意外修改
             });
 
             if (result.success) {
                 showToast('成功', '配置已保存', 'success');
-                branchInput.value = branch; // 更新UI上的分支名
+                branchInput.value = branch;
 
-                // --- 更新前端 token 状态 ---
-                if (token) { // 如果用户输入了新的 token 并保存成功
+                if (token) {
                     initialConfigHasToken = true;
-                    githubTokenInput.placeholder = "访问令牌已保存"; // 更新placeholder
-                    githubTokenInput.value = ""; // 清空输入框的值
+                    githubTokenInput.placeholder = "访问令牌已保存";
+                    githubTokenInput.value = "";
                 } else if (!token && !initialConfigHasToken) {
-                    // 如果用户没输入 token，且原本就没有 token，保持原样
                     githubTokenInput.placeholder = "例如: ghp_xxxxxxxxxxxx";
                     githubTokenInput.value = "";
                 } else if (!token && initialConfigHasToken) {
-                    // 如果用户没输入 token，但原本有 token，恢复 placeholder
                     githubTokenInput.placeholder = "访问令牌已保存";
                     githubTokenInput.value = "";
                 }
-
-                // --- 结束更新前端 token 状态 ---
 
                 hideLoading();
                 return true;
@@ -965,28 +910,33 @@ document.addEventListener('DOMContentLoaded', function() {
         }
     }
 
-    // --- 修改：保存定时存档设置函数 (不再直接控制定时器) ---
     async function saveAutoSaveConfiguration() {
         const enabled = autoSaveEnabledSwitch.checked;
         const interval = parseInt(autoSaveIntervalInput.value, 10) || 30;
         const targetTag = autoSaveTargetTagInput.value.trim();
+        const mode = autoSaveModeCreateRadio.checked ? 'create' : 'overwrite';
+        
+        // 获取浏览器时区偏移（分钟）
+        const timezoneOffset = -new Date().getTimezoneOffset();
 
-        if (enabled && !targetTag) {
-            showToast('警告', '启用定时存档时，必须指定一个要覆盖的目标存档标签。', 'warning');
+        // 覆盖模式必须提供目标标签
+        if (enabled && mode === 'overwrite' && !targetTag) {
+            showToast('警告', '覆盖模式下，启用定时存档时必须指定一个要覆盖的目标存档标签。', 'warning');
             return false;
         }
 
         try {
             showLoading('正在保存定时存档设置...');
-            // 调用 /config 接口保存所有配置 (后端会根据新配置重启定时器)
             const result = await apiCall('config', 'POST', {
                 repo_url: repoUrlInput.value.trim(),
-                github_token: githubTokenInput.value.trim(), // 注意：这里如果为空或******，可能导致token被清空
+                github_token: githubTokenInput.value.trim(),
                 display_name: displayNameInput.value.trim(),
                 branch: branchInput.value.trim() || 'main',
                 autoSaveEnabled: enabled,
                 autoSaveInterval: interval,
-                autoSaveTargetTag: targetTag
+                autoSaveTargetTag: targetTag,
+                autoSaveMode: mode,
+                autoSaveTimezoneOffset: timezoneOffset
             });
 
             if (result.success) {
@@ -1004,10 +954,9 @@ document.addEventListener('DOMContentLoaded', function() {
         }
     }
 
-    // 显示确认对话框 ... (保持不变) ...
     function showConfirmDialog(title, message, callback, confirmButtonType = 'danger') { 
         const titleElement = document.getElementById('confirmModalLabel');
-        const messageElement = document.getElementById('confirm-message'); // 直接获取元素
+        const messageElement = document.getElementById('confirm-message');
 
         if (titleElement) {
              titleElement.textContent = title;
@@ -1016,14 +965,13 @@ document.addEventListener('DOMContentLoaded', function() {
         }
 
         if (messageElement) {
-            messageElement.innerHTML = message; // 设置消息
+            messageElement.innerHTML = message;
         } else {
             console.error('[Cloud Saves UI] Confirm dialog message element (confirm-message) not found!');
         }
         
         confirmCallback = callback;
         
-        // 确认按钮样式设置 (假设 confirmActionBtn 能正确获取)
         confirmActionBtn.classList.remove('btn-danger', 'btn-primary', 'btn-success', 'btn-warning', 'btn-secondary'); 
         if (confirmButtonType === 'danger') {
             confirmActionBtn.classList.add('btn-danger');
@@ -1033,17 +981,14 @@ document.addEventListener('DOMContentLoaded', function() {
             confirmActionBtn.classList.add('btn-secondary'); 
         }
         
-        // 确保 confirmModal 实例存在
         if (confirmModal && typeof confirmModal.show === 'function') {
              confirmModal.show();
         } else {
              console.error('[Cloud Saves UI] Confirm dialog modal instance (confirmModal) is invalid or missing!');
-             showToast('错误', '无法显示确认对话框', 'error'); // 给用户一个反馈
+             showToast('错误', '无法显示确认对话框', 'error');
         }
     }
 
-    // 绑定事件
-    // --- 使用辅助函数安全地添加监听器 ---
     function safeAddEventListener(element, event, handler, elementIdForLogging) {
         if (element) {
             element.addEventListener(event, handler);
@@ -1052,19 +997,19 @@ document.addEventListener('DOMContentLoaded', function() {
         }
     }
 
-    // --- 事件监听器绑定 --- (MODIFIED - 调用 authorize 时不再传 token)
+    // 事件监听器绑定
     safeAddEventListener(initRepoBtn, 'click', () => {
         showConfirmDialog(
             '确认强制初始化仓库',
             '<strong>警告：此操作将删除 data 目录下的现有 Git 历史 (如果存在)！</strong><br>确定要强制初始化本地 Git 仓库并配置远程地址吗？',
             initializeRepository,
-            'danger' // 危险操作用红色按钮
+            'danger'
         );
     }, 'init-repo-btn');
     safeAddEventListener(configureBtn, 'click', saveConfiguration, 'configure-btn');
     safeAddEventListener(authorizeBtn, 'click', async () => {
         const repoUrl = repoUrlInput.value.trim();
-        const tokenInputValue = githubTokenInput.value.trim(); // 读取当前输入框的值
+        const tokenInputValue = githubTokenInput.value.trim();
         const displayName = displayNameInput.value.trim();
         const branch = branchInput.value.trim() || 'main';
 
@@ -1072,23 +1017,15 @@ document.addEventListener('DOMContentLoaded', function() {
             showToast('错误', '仓库 URL 不能为空', 'error');
             return;
         }
-        // 检查1: 如果用户 *输入了新* token
         if (tokenInputValue && tokenInputValue !== "") {
             showToast('提示', '检测到新的访问令牌输入，请先点击"配置"按钮保存新令牌，然后再点击"授权并连接"。', 'info');
-            return; // 阻止直接授权
+            return;
         }
-        // 检查2: 如果用户 *没输入新* token，且 *后台原本就没* token
         if (!tokenInputValue && !initialConfigHasToken) {
             showToast('错误', 'GitHub 访问令牌不能为空，请在上方输入或点击"配置"保存。', 'error');
             return;
         }
 
-        // 如果执行到这里，说明：
-        // - URL 已输入
-        // - 要么输入框为空且后台有 token (initialConfigHasToken is true) -> 使用后台 token
-        // (已经排除了"输入框为空且后台没token" 和 "输入框有新token" 的情况)
-
-        // 执行授权 (不再传递 tokenInputValue)
         await authorize(repoUrl, displayName, branch);
 
     }, 'authorize-btn');
@@ -1118,12 +1055,26 @@ document.addEventListener('DOMContentLoaded', function() {
     safeAddEventListener(autoSaveEnabledSwitch, 'change', () => {
         autoSaveOptionsDiv.style.display = autoSaveEnabledSwitch.checked ? 'flex' : 'none';
     }, 'auto-save-enabled');
+
+    // 自动存档模式切换事件
+    safeAddEventListener(autoSaveModeOverwriteRadio, 'change', () => {
+        if (autoSaveModeOverwriteRadio.checked) {
+            autoSaveTargetTagRow.style.display = '';
+            autoSaveModeHint.textContent = '覆盖模式：每次自动存档将覆盖指定的已有存档标签。';
+        }
+    }, 'auto-save-mode-overwrite');
+
+    safeAddEventListener(autoSaveModeCreateRadio, 'change', () => {
+        if (autoSaveModeCreateRadio.checked) {
+            autoSaveTargetTagRow.style.display = 'none';
+            autoSaveModeHint.textContent = '创建模式：每次自动存档将创建新存档（命名格式：YYYY-MM-DD - HHMM (Auto Save)），使用浏览器时区。';
+        }
+    }, 'auto-save-mode-create');
+
     safeAddEventListener(saveAutoSaveSettingsBtn, 'click', saveAutoSaveConfiguration, 'save-auto-save-settings-btn');
 
-    // 新增：检查更新按钮事件
     safeAddEventListener(checkUpdateBtn, 'click', checkAndApplyUpdate, 'check-update-btn');
 
-    // --- 新增：初始化仓库函数 ---
     async function initializeRepository() {
         try {
             showLoading('正在初始化仓库...');
@@ -1132,15 +1083,12 @@ document.addEventListener('DOMContentLoaded', function() {
             if (result.success) {
                 let message = result.message || '仓库初始化成功';
                 if (result.warning) {
-                    // 显示警告，并提示重新授权
                     showToast('警告', message, 'warning');
-                    showToast('提示', '初始化完成，请点击 **授权并连接** 按钮以验证并同步远程仓库。', 'info'); // 添加提示
+                    showToast('提示', '初始化完成，请点击 **授权并连接** 按钮以验证并同步远程仓库。', 'info');
                 } else {
-                    // 显示成功，并提示重新授权
                     showToast('成功', message, 'success');
-                    showToast('提示', '初始化完成，请点击 **授权并连接** 按钮以验证并同步远程仓库。', 'info'); // 添加提示
+                    showToast('提示', '初始化完成，请点击 **授权并连接** 按钮以验证并同步远程仓库。', 'info');
                 }
-                // 初始化后刷新状态 (可能显示未授权)
                 await refreshStatus();
             } else {
                 throw new Error(result.message || '初始化仓库失败');
@@ -1154,7 +1102,6 @@ document.addEventListener('DOMContentLoaded', function() {
         }
     }
 
-    // --- 新增：检查更新函数 ---
     async function checkAndApplyUpdate() {
         try {
             showLoading('正在检查插件更新...');
@@ -1175,7 +1122,6 @@ document.addEventListener('DOMContentLoaded', function() {
                 }
                 showToast('检查更新', message, type);
             } else {
-                // 如果 success 为 false，也显示消息
                  showToast('更新失败', result.message || '检查或应用更新时发生未知错误。', 'error');
             }
 
@@ -1187,26 +1133,21 @@ document.addEventListener('DOMContentLoaded', function() {
         }
     }
 
-    // --- 绑定事件 --- (MODIFIED for githubTokenInput focus/blur)
     safeAddEventListener(githubTokenInput, 'focus', () => {
         if (githubTokenInput.placeholder === "访问令牌已保存") {
-            githubTokenInput.placeholder = "输入新令牌以覆盖..."; // 提供更清晰的提示
+            githubTokenInput.placeholder = "输入新令牌以覆盖...";
         }
     }, 'github-token-focus');
 
     safeAddEventListener(githubTokenInput, 'blur', () => {
-        // 当输入框失去焦点时
         if (githubTokenInput.value === "" && initialConfigHasToken) {
-            // 如果输入框是空的，并且我们知道后台本来是有token的
-            githubTokenInput.placeholder = "访问令牌已保存"; // 恢复提示
+            githubTokenInput.placeholder = "访问令牌已保存";
         } else if (githubTokenInput.value === "" && !initialConfigHasToken) {
-             // 如果输入框是空的，且后台本来就没token
-             githubTokenInput.placeholder = "例如: ghp_xxxxxxxxxxxx"; // 恢复默认提示
+            githubTokenInput.placeholder = "例如: ghp_xxxxxxxxxxxx";
         }
-        // 如果用户输入了内容，placeholder 不会被显示，所以不需要处理这种情况
     }, 'github-token-blur');
 
     // 初始化
     init();
 
-}); // DOMContentLoaded 结束 
+}); // DOMContentLoaded 结束

--- a/public/script.js
+++ b/public/script.js
@@ -355,7 +355,7 @@ document.addEventListener('DOMContentLoaded', function() {
                 autoSaveModeCreateRadio.checked = true;
                 autoSaveModeOverwriteRadio.checked = false;
                 autoSaveTargetTagRow.style.display = 'none';      // 创建模式不需要目标标签
-                autoSaveModeHint.textContent = '创建模式：每次自动存档将创建新存档（命名格式：YYYY-MM-DD - HHMM (Auto Save)），使用浏览器时区。';
+                autoSaveModeHint.textContent = '创建模式：每次自动存档将创建新存档（命名格式：Auto Save | YYYY-MM-DD | HHMM），使用浏览器时区。';
             } else {
                 autoSaveModeOverwriteRadio.checked = true;
                 autoSaveModeCreateRadio.checked = false;
@@ -913,7 +913,7 @@ document.addEventListener('DOMContentLoaded', function() {
     /**
      * createSave - 创建一个新的云端存档
      * 
-     * 存档名称如果为空，自动生成格式：YYYY-MM-DD - HHMM
+     * 存档名称如果为空，自动生成格式：YYYY-MM-DD | HHMM
      * 创建成功后清空输入框并刷新列表。
      * 
      * @param {string} name - 存档名称
@@ -1499,7 +1499,7 @@ document.addEventListener('DOMContentLoaded', function() {
     safeAddEventListener(autoSaveModeCreateRadio, 'change', () => {
         if (autoSaveModeCreateRadio.checked) {
             autoSaveTargetTagRow.style.display = 'none';  // 隐藏目标标签输入
-            autoSaveModeHint.textContent = '创建模式：每次自动存档将创建新存档（命名格式：YYYY-MM-DD - HHMM (Auto Save)），使用浏览器时区。';
+            autoSaveModeHint.textContent = '创建模式：每次自动存档将创建新存档（命名格式：Auto Save | YYYY-MM-DD | HHMM），使用浏览器时区。';
         }
     }, 'auto-save-mode-create');
 

--- a/public/style.css
+++ b/public/style.css
@@ -1,116 +1,393 @@
-/* 全局样式 */
+/* ============================================================================
+ * SillyTavern Cloud Saves 插件 - 前端样式表
+ * ============================================================================
+ * 
+ * 本样式表为云存档插件的前端界面提供视觉设计。
+ * 采用暗色主题，与 SillyTavern 的整体设计风格保持一致。
+ * 
+ * 设计原则：
+ *   - 暗色背景减少眼部疲劳
+ *   - 柔和的阴影和过渡效果提升现代感
+ *   - 响应式布局适配不同屏幕尺寸
+ *   - CSS 变量便于全局主题色统一管理
+ *   - Bootstrap 5 框架基础上进行定制化覆盖
+ * 
+ * ============================================================================
+ */
+
+/* =========================== CSS 变量：主题色定义 =========================== */
 :root {
-    --primary-color: #4a6bff;
-    --secondary-color: #6c757d;
-    --success-color: #28a745;
-    --info-color: #17a2b8;
-    --danger-color: #dc3545;
-    --light-color: #f8f9fa;
-    --dark-color: #343a40;
+    --bs-primary: #7c71f5;        /* 主色调：柔和的紫色，用于主要按钮和强调元素 */
+    --bs-primary-rgb: 124, 113, 245;  /* 主色调 RGB 值，用于 rgba() 透明度计算 */
+    --bs-success: #62d462;         /* 成功色：鲜绿色，用于成功状态和创建操作 */
+    --bs-success-rgb: 98, 212, 98;
+    --bs-warning: #fad95f;         /* 警告色：暖黄色，用于警告提示和覆盖操作 */
+    --bs-warning-rgb: 250, 217, 95;
+    --bs-danger: #ff6c6c;          /* 危险色：红色，用于删除操作和错误提示 */
+    --bs-danger-rgb: 255, 108, 108;
 }
 
+/* =========================== 全局基础样式 =========================== */
+
+/* 
+ * body 样式
+ * - 使用系统字体栈确保跨平台一致的阅读体验
+ * - 深色背景 (#202123) 搭配白色文字，符合暗色主题
+ */
 body {
-    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, 
+                 Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+    background-color: #202123;
+    color: #ffffff;
 }
 
-/* 卡片样式 */
+/* =========================== 卡片组件样式 =========================== */
+
+/* 
+ * 卡片容器
+ * - 比 body 稍亮的背景色 (#2d2d31)，形成层次感
+ * - 圆角和阴影增强立体感
+ * - 悬停时微微上浮 (translateY)，提供交互反馈
+ */
 .card {
+    background-color: #2d2d31;
+    border: 1px solid #444444;
     border-radius: 10px;
-    overflow: hidden;
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
+    margin-bottom: 15px;
     transition: transform 0.2s, box-shadow 0.2s;
-    border: none;
 }
 
+/* 卡片悬停效果：上浮 2px + 加深阴影 */
 .card:hover {
-    transform: translateY(-5px);
-    box-shadow: 0 10px 20px rgba(0, 0, 0, 0.1);
+    transform: translateY(-2px);
+    box-shadow: 0 8px 16px rgba(0, 0, 0, 0.4);
 }
 
+/* 卡片头部：半透明黑色背景叠加，底部边框分隔 */
 .card-header {
-    border-bottom: none;
-    padding: 0.75rem 1.25rem;
+    background-color: rgba(0, 0, 0, 0.2);
+    border-bottom: 1px solid #444444;
+    font-weight: bold;
 }
 
-/* 按钮样式 */
-.btn {
-    border-radius: 5px;
-    padding: 0.5rem 1rem;
-    font-weight: 500;
-    transition: all 0.2s;
+/* 卡片主体内边距 */
+.card-body {
+    padding: 15px;
 }
 
+/* =========================== 按钮样式定制 =========================== */
+
+/* 主按钮：使用 CSS 变量确保主题色一致 */
 .btn-primary {
-    background-color: var(--primary-color);
-    border-color: var(--primary-color);
+    background-color: var(--bs-primary);
+    border-color: var(--bs-primary);
 }
 
-.btn-primary:hover {
-    background-color: #3857e0;
-    border-color: #3857e0;
+/* 成功按钮 */
+.btn-success {
+    background-color: var(--bs-success);
+    border-color: var(--bs-success);
 }
 
-.btn-info {
-    background-color: var(--info-color);
-    border-color: var(--info-color);
-    color: white;
+/* 警告按钮：深色文字确保在黄色背景上的可读性 */
+.btn-warning {
+    background-color: var(--bs-warning);
+    border-color: var(--bs-warning);
+    color: #202123;
 }
 
-.btn-info:hover {
-    background-color: #138496;
-    border-color: #138496;
-    color: white;
+/* 危险按钮 */
+.btn-danger {
+    background-color: var(--bs-danger);
+    border-color: var(--bs-danger);
 }
 
-/* 表单样式 */
-.form-control {
-    border-radius: 5px;
-    padding: 0.75rem 1rem;
-    border: 1px solid #e0e0e0;
+/* =========================== 存档卡片（save-card）样式 =========================== */
+
+/* 
+ * 存档卡片容器：相对定位，为"当前存档"徽章的绝对定位提供参考系
+ */
+.save-card {
+    position: relative;
 }
 
-.form-control:focus {
-    border-color: var(--primary-color);
-    box-shadow: 0 0 0 0.25rem rgba(74, 107, 255, 0.25);
+/* 
+ * 操作按钮区域：右对齐，按钮之间有间距
+ */
+.save-card .action-buttons {
+    display: flex;
+    justify-content: flex-end;
+    gap: 5px;
 }
 
-/* 状态框样式 */
-.status-box {
-    max-height: 200px;
+/* 
+ * 时间戳文字：较暗的灰色，字体稍小，不喧宾夺主
+ */
+.save-timestamp {
+    color: #aaaaaa;
+    font-size: 0.9rem;
+}
+
+/* 
+ * 描述文字：浅灰色
+ * - white-space: pre-line 保留换行符，让描述中有多行文本时正确显示
+ * - max-height + overflow-y 限制描述区域高度，防止长描述撑破卡片
+ */
+.save-description {
+    color: #dddddd;
+    margin-top: 8px;
+    white-space: pre-line;
+    max-height: 100px;
     overflow-y: auto;
-    border: 1px solid #ddd;
-    font-family: monospace;
-    font-size: 0.85rem;
-    white-space: pre-wrap;
-    word-break: break-all;
 }
 
-/* 通知样式 */
-.toast {
+/* 
+ * "当前存档"徽章
+ * - 绝对定位在卡片右上角
+ * - 紫色背景白色文字，圆角胶囊形状
+ * - z-index: 10 确保在卡片内容之上
+ */
+.save-current-badge {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    background-color: var(--bs-primary);
+    color: white;
+    padding: 3px 10px;
     border-radius: 10px;
-    border: none;
+    font-size: 0.8rem;
+    z-index: 10;
 }
 
+/* =========================== 加载覆盖层 =========================== */
+
+/* 
+ * 全屏半透明加载遮罩
+ * - 固定定位覆盖整个视口
+ * - 半透明黑色背景，使下方内容隐约可见
+ * - flex 布局居中加载动画
+ * - 默认隐藏 (display: none)
+ */
+.loading-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.7);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 1000;
+    display: none;
+}
+
+/* 加载动画容器 */
+.spinner-container {
+    text-align: center;
+}
+
+/* 加载文字提示 */
+.spinner-message {
+    margin-top: 15px;
+    font-size: 1.2rem;
+    color: white;
+}
+
+/* =========================== 各地区域间距 =========================== */
+
+/* 授权区域底部间距，与下方存档区域分隔 */
+#auth-section {
+    margin-bottom: 30px;
+}
+
+/* =========================== 存档列表容器 =========================== */
+
+/* 
+ * 存档列表可滚动区域
+ * - 最大高度 70vh，超出时垂直滚动
+ * - 右侧留出滚动条空间
+ */
+#saves-container {
+    max-height: 70vh;
+    overflow-y: auto;
+    padding-right: 5px;
+}
+
+/* 
+ * 自定义滚动条样式（WebKit 内核浏览器）
+ * 让滚动条与暗色主题协调
+ */
+
+/* 滚动条轨道 */
+#saves-container::-webkit-scrollbar {
+    width: 8px;
+}
+#saves-container::-webkit-scrollbar-track {
+    background: #2d2d31;
+    border-radius: 10px;
+}
+
+/* 滚动条滑块 */
+#saves-container::-webkit-scrollbar-thumb {
+    background: #555555;
+    border-radius: 10px;
+}
+
+/* 滑块悬停时变亮 */
+#saves-container::-webkit-scrollbar-thumb:hover {
+    background: #777777;
+}
+
+/* =========================== 状态栏 =========================== */
+
+/* 
+ * 底部状态栏
+ * - 与卡片相同的背景色，形成视觉统一
+ * - 较小的字体 (0.9rem)，作为辅助信息
+ */
+#status-bar {
+    margin-top: 20px;
+    padding: 10px;
+    background-color: #2d2d31;
+    border-radius: 5px;
+    font-size: 0.9rem;
+}
+
+/* =========================== 分段标题 =========================== */
+
+/* 
+ * 存档列表的分段标题区域
+ * - 标题和操作按钮左右分布
+ * - 底部边框分隔
+ */
+.section-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 15px;
+    padding-bottom: 10px;
+    border-bottom: 1px solid #444444;
+}
+
+/* =========================== 搜索和排序控件 =========================== */
+
+/* 排序下拉框最大宽度限制 */
+.filter-dropdown {
+    max-width: 200px;
+}
+
+/* 
+ * 搜索框
+ * - 暗色背景和边框与主题统一
+ * - 白色文字确保可读性
+ */
+#search-box {
+    background-color: #2d2d31;
+    border: 1px solid #444444;
+    color: white;
+}
+
+/* =========================== 模态框定制 =========================== */
+
+/* 模态框内容区：暗色背景 */
+.modal-content {
+    background-color: #2d2d31;
+    color: white;
+    border: 1px solid #444444;
+}
+
+/* 模态框头部和底部的分隔线 */
+.modal-header {
+    border-bottom: 1px solid #444444;
+}
+.modal-footer {
+    border-top: 1px solid #444444;
+}
+
+/* =========================== 表单控件定制 =========================== */
+
+/* 
+ * 输入框和选择框
+ * - 暗色背景比卡片稍亮 (#383838)，形成层次
+ * - 聚焦时变色为主色调，提供视觉反馈
+ * - rgba() 阴影使用 CSS 变量实现半透明主色光晕
+ */
+.form-control, .form-select {
+    background-color: #383838;
+    border: 1px solid #555555;
+    color: white;
+}
+
+.form-control:focus, .form-select:focus {
+    background-color: #3a3a3a;
+    color: white;
+    border-color: var(--bs-primary);
+    box-shadow: 0 0 0 0.25rem rgba(var(--bs-primary-rgb), 0.25);
+}
+
+/* =========================== Toast 通知组件 =========================== */
+
+/* 
+ * Toast 通知容器
+ * - 固定定位在右上角
+ * - 高 z-index 确保在所有内容之上
+ */
+.toast-container {
+    position: fixed;
+    top: 20px;
+    right: 20px;
+    z-index: 1050;
+}
+
+/* Toast 本体：暗色背景 */
+.toast {
+    background-color: #2d2d31;
+    color: white;
+    border: 1px solid #444444;
+}
+
+/* Toast 头部 */
 .toast-header {
-    border-bottom: none;
+    background-color: rgba(0, 0, 0, 0.2);
+    color: white;
+    border-bottom: 1px solid #444444;
 }
 
-/* 动画 */
-@keyframes fadeIn {
-    from { opacity: 0; transform: translateY(20px); }
-    to { opacity: 1; transform: translateY(0); }
+/* =========================== 空状态占位 =========================== */
+
+/* 
+ * 无存档时的空状态提示
+ * - 居中布局
+ * - 大图标 + 灰色文字
+ * - 足够的上下内边距
+ */
+.empty-state {
+    text-align: center;
+    padding: 50px 20px;
+    color: #aaaaaa;
 }
 
-.fade-in {
-    animation: fadeIn 0.3s ease-out forwards;
+/* 空状态图标：3rem 大尺寸，深灰低调 */
+.empty-state i {
+    font-size: 3rem;
+    margin-bottom: 15px;
+    color: #555555;
 }
 
-/* 响应式调整 */
-@media (max-width: 768px) {
-    .container {
-        padding: 10px;
-    }
-    
-    .card-body {
-        padding: 1rem;
-    }
-} 
+/* =========================== 变更徽章 =========================== */
+
+/* 
+ * 差异对比中的变更数量徽章
+ * - 小字体小内边距
+ * - 灰色背景，作为辅助信息不喧宾夺主
+ * - vertical-align: middle 与文件名对齐
+ */
+.badge-changes {
+    font-size: 0.7rem;
+    padding: 3px 7px;
+    margin-left: 5px;
+    vertical-align: middle;
+    background-color: #555555;
+}


### PR DESCRIPTION
修改的核心目标是解决嵌套 Git 仓库（子插件的 .git 目录）在备份和还原时导致档案流失或错误的问题，同时增加了自动存档的「创建新模式」功能。

索引档案（index.js）的变更：

- 修正了嵌套 Git 仓库无法被完整备份的核心缺陷。旧版本在处理 `data/default-user/extensions/` 下各个子插件自带的 .git 目录时，会导致这些目录被 Git 视为子模组（Gitlink），存档后还原时子插件的内部档案会全部遗失。新版本采用「重命名隐藏法」，在执行任何 Git 操作前，会递归扫描并将所有嵌套的 .git 目录临时重命名为 `_git_cloud_backup`（一个不带点前缀的名称），操作完成后再恢复原名，从而让这些目录以普通档案形式被完整追踪。

- 新增了存档还原后的双重恢复机制。除了上述的「恢复操作前被隐藏的 .git 目录」外，还新增了 `restoreCheckoutGit` 函数，专门处理执行存档还原（git checkout）时，从云端下载回来的那些被改名为 `_git_cloud_backup` 的目录，将它们自动恢复为正常可用的 .git 目录，确保子插件在切换存档后仍能正常运作。

- 重写了存档列表的同步机制，修复了删除远端存档后本地仍显示幽灵存档的问题。旧版本直接拉取所有远端标签，无法区分哪些是已删除的。新版本先使用 `git ls-remote` 快速获取远端真实存在的存档标签清单，然后比对并清理本地已不存在于远端的残留标签，再拉取详细资讯，确保显示的存档列表与远端仓库完全一致。

- 修复了 Git 状态查询（getGitStatus）无法正确显示子插件档案变更的问题。旧版本在检查工作区状态时，因嵌套 .git 目录的干扰，无法侦测到子插件内部档案的增删改。新版本在查询状态前同样采用重命名隐藏法，先将嵌套 .git 目录隐藏，获取真实的变更状态后再恢复，让状态栏能准确反映所有档案的修改情况。

- 新增了自动存档的「创建新模式」。原有的自动存档仅支援「覆盖模式」，即定期覆盖一个指定的存档标签。现在增加了「创建模式」，每次自动存档会像手动存档一样创建一个全新的存档，命名格式为「YYYY-MM-DD - HHMM (Auto Save)」，并支援根据使用者浏览器的时区来调整存档名称中的时间，解决了伺服器时区与使用者时区不同导致命名混乱的问题。

- 移除了旧版初始化仓库时的破坏性操作。旧版本在初始化时会强制递归删除 extensions 目录下的所有嵌套 .git 和 .gitignore 档案以及尝试修复 Gitlink 索引条目，这些操作不仅复杂而且可能导致资料遗失。新版本完全移除了这些步骤，改由上述的更安全的「重命名隐藏法」来处理嵌套 Git 问题。

- 简化了初始化仓库时建立的 .gitignore 档案逻辑，并增加了对旧版本隐藏目录 `.git_cloud_hidden` 的忽略规则，确保从旧版本升级的用户不会意外提交旧格式的备份残留档案。

- 优化了检查插件更新的端点实作，使其更简洁可靠。

前端脚本（script.js）的变更：

- 新增了自动存档模式的切换介面。在定时存档设定区域增加了两个单选按钮：「覆盖已有存档」和「创建新存档」。当选择创建模式时，会自动隐藏「目标存档标签」输入框，并显示对应的模式说明文字；选择覆盖模式时则恢复显示目标标签输入框，让使用者清楚了解当前选择的模式。

- 修正了创建存档时名称为空的行为。旧版本在存档名称为空时会直接报错，新版本改为自动生成预设名称，格式为「YYYY-MM-DD - HHMM」（使用当前时间），同时在输入框的占位符文字中提示使用者可以留空以使用自动命名。

- 在保存定时存档设定时，现在会同时提交使用者选择的自动存档模式（覆盖或创建）以及浏览器时区偏移量到后端，确保定时存档能按照使用者期望的方式和时区执行。

- 增加了对新设定栏位（自动存档模式、时区偏移）的初始化载入和显示逻辑，确保页面刷新后能正确显示之前保存的设定。

- 整体程式码加入了大量详细的中文注解，大幅提升了程式码的可读性和可维护性。

前端页面（index.html）的变更：

- 在定时存档设定区域中新增了一组模式选择按钮（覆盖已有存档／创建新存档），以及一段动态变化的模式说明提示文字，取代了旧版只支援覆盖模式的单一输入框布局。

- 将创建存档的名称输入框占位符文字更新为「存档名称（留空则自动命名为「YYYY-MM-DD - HHMM」）」，提示使用者可以使用自动命名功能。

- 整体 HTML 档案加入了结构化注解，对各个区块和元件的用途进行了标注。

样式表（style.css）的变更：

- 仅新增了详细的设计说明注解，无任何功能性或视觉上的实质变更。

依赖设定档（package.json 及 package-lock.json）的变更：

- 无任何变更。